### PR TITLE
35 event overview

### DIFF
--- a/back-end/resources/testing/test_doubleEvent.json
+++ b/back-end/resources/testing/test_doubleEvent.json
@@ -97,7 +97,7 @@
       "rules": [
         {
           "id": "mainSwitch flipped",
-          "description": "Als de mainSwitch true is, gebeurd er nix",
+          "description": "Als de mainSwitch true is, gebeurt er niks",
           "limit": 1,
           "conditions": {
             "operator": "OR",
@@ -126,7 +126,7 @@
       "name": "eventB",
       "rules": [
         {
-          "id": "",
+          "id": "weldoen",
           "description": "Als rule 'mainSwitch flipped' is gedaan, dan moet greenLight1 aangaan",
           "limit": 1,
           "conditions": {

--- a/back-end/resources/testing/test_handle_event.json
+++ b/back-end/resources/testing/test_handle_event.json
@@ -1,0 +1,126 @@
+{
+  "general": {
+    "name": "Escape X",
+    "duration": "00:30:00",
+    "host": "localhost",
+    "port": 1883
+  },
+  "timers": [
+    {
+      "id": "timer1",
+      "duration": "10s"
+    },
+    {
+      "id": "timer2",
+      "duration": "5s"
+    },
+    {
+      "id": "timer3",
+      "duration": "1m"
+    },
+    {
+      "id": "timer4",
+      "duration": "1h"
+    },
+    {
+      "id": "timer5",
+      "duration": "20s"
+    },
+    {
+      "id": "timer6",
+      "duration": "5s"
+    }
+  ],
+  "devices": [
+    {
+      "id": "display",
+      "description": "Laat hint zien",
+      "input": {
+        "display": "string"
+      },
+      "output": {
+        "display": {
+          "type": "string",
+          "instructions": {
+            "hint": "string"
+          }
+        }
+      }
+    },
+    {
+      "id": "display2",
+      "description": "Laat hint zien",
+      "input": {
+        "display": "string"
+      },
+      "output": {
+        "display": {
+          "type": "string",
+          "instructions": {
+            "hint": "string"
+          }
+        }
+      }
+    }
+  ],
+  "puzzles": [
+    {
+      "name": "Puzzle",
+      "rules": [
+        {
+          "id": "rule",
+          "description": "My rule",
+          "limit": 1,
+          "conditions": {
+            "type": "device",
+            "type_id": "display",
+            "constraints": {
+              "component_id": "display",
+              "value": "test",
+              "comparison": "eq"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Puzzle2",
+      "rules": [
+        {
+          "id": "rule2",
+          "description": "My second rule",
+          "limit": 10,
+          "conditions": {
+            "type": "device",
+            "type_id": "display",
+            "constraints": {
+              "component_id": "display",
+              "value": "test2",
+              "comparison": "eq"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Puzzle3",
+      "rules": [
+        {
+          "id": "rule3",
+          "description": "My third rule",
+          "limit": 10,
+          "conditions": {
+            "type": "device",
+            "type_id": "display",
+            "constraints": {
+              "component_id": "display",
+              "value": "test3",
+              "comparison": "eq"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "general_events": []
+}

--- a/back-end/resources/testing/test_instruction.json
+++ b/back-end/resources/testing/test_instruction.json
@@ -1,0 +1,73 @@
+{
+  "general": {
+    "name": "Escape X",
+    "duration": "00:30:00",
+    "host": "localhost",
+    "port": 1883
+  },
+  "timers": [
+    {
+      "id": "timer1",
+      "duration": "10s"
+    },
+    {
+      "id": "timer2",
+      "duration": "5s"
+    },
+    {
+      "id": "timer3",
+      "duration": "1m"
+    },
+    {
+      "id": "timer4",
+      "duration": "1h"
+    },
+    {
+      "id": "timer5",
+      "duration": "20s"
+    },
+    {
+      "id": "timer6",
+      "duration": "5s"
+    }
+  ],
+  "devices": [
+    {
+      "id": "display",
+      "description": "Laat hint zien",
+      "input": {
+        "display": "string"
+      },
+      "output": {
+        "display": {
+          "type": "string",
+          "instructions": {
+            "hint": "string"
+          }
+        }
+      }
+    }
+  ],
+  "puzzles": [
+    {
+      "name": "Puzzle",
+      "rules": [
+        {
+          "id": "rule",
+          "description": "My rule",
+          "limit": 0,
+          "conditions": {
+            "type": "device",
+            "type_id": "display",
+            "constraints": {
+              "component_id": "display",
+              "value": "test",
+              "comparison": "eq"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "general_events": []
+}

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -250,7 +250,7 @@ func (handler *Handler) SendEventStatus() {
 	message := Message{
 		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
-		Type:     "event-status",
+		Type:     "event status",
 		Contents: status,
 	}
 	jsonMessage, _ := json.Marshal(&message)

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -343,7 +343,7 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 					}
 					handler.SendEventStatus()
 				}
-			case "name":
+			case "send name":
 				{
 					message := Message{
 						DeviceID: "back-end",

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -254,7 +254,7 @@ func (handler *Handler) SendEventStatus() {
 		Contents: status,
 	}
 	jsonMessage, _ := json.Marshal(&message)
-	logrus.Infof("sending event status to front-end: %s", fmt.Sprint(message.Contents))
+	logrus.Info("sending event status to front-end")
 	handler.Communicator.Publish("front-end", string(jsonMessage), 3)
 }
 

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -232,7 +232,7 @@ func (handler *Handler) SendStatus(deviceID string) {
 		}
 	}
 	jsonMessage, err := json.Marshal(&message)
-	if err != nil {
+	if err != nil { // This cannot be tested
 		logrus.Errorf("error occurred while constructing message to publish: %v", err)
 	} else {
 		logrus.Info("sending status data to front-end: " + fmt.Sprint(message.Contents))
@@ -251,7 +251,7 @@ func (handler *Handler) SendEventStatus() {
 	}
 
 	jsonMessage, err := json.Marshal(&message)
-	if err != nil {
+	if err != nil { // This cannot be tested
 		logrus.Errorf("error occurred while constructing message to publish: %v", err)
 	} else {
 		logrus.Infof("sending event status to front-end: %s", fmt.Sprint(message.Contents))
@@ -263,7 +263,6 @@ func (handler *Handler) SendEventStatus() {
 // status is json object with key ruleName and value true (if executed == limit) or false
 func (handler *Handler) getEventStatus() []map[string]interface{} {
 	var list []map[string]interface{}
-	fmt.Print(handler.Config.Puzzles)
 	for _, rule := range handler.Config.RuleMap {
 		var status = make(map[string]interface{})
 		status["id"] = rule.ID
@@ -285,7 +284,7 @@ func (handler *Handler) SendInstruction(clientID string, instructions []config.C
 	}
 
 	jsonMessage, err := json.Marshal(&message)
-	if err != nil {
+	if err != nil { // This cannot be tested
 		logrus.Errorf("error occurred while constructing message to publish: %v", err)
 	} else {
 		logrus.Infof("sending instruction data to %s: %s", clientID, fmt.Sprint(message.Contents))
@@ -314,7 +313,7 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 				},
 			}
 			jsonMessage, err := json.Marshal(&message)
-			if err != nil {
+			if err != nil { // This cannot be tested
 				logrus.Errorf("error occurred while constructing message to publish: %v", err)
 			} else {
 				handler.Communicator.Publish("client-computers", string(jsonMessage), 3)
@@ -337,7 +336,7 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 				Contents: raw.Contents,
 			}
 			jsonMessage, err := json.Marshal(&message)
-			if err != nil {
+			if err != nil { // This cannot be tested
 				logrus.Errorf("error occurred while constructing message to publish: %v", err)
 			} else {
 				handler.Communicator.Publish("hint", string(jsonMessage), 3)
@@ -360,7 +359,7 @@ func (handler *Handler) HandleEvent(id string) {
 // SendName sends name of escape room to front-end
 func (handler *Handler) SendName() {
 	message := Message{
-		DeviceID: "front-end",
+		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 		Type:     "name",
 		Contents: map[string]string{
@@ -368,7 +367,7 @@ func (handler *Handler) SendName() {
 		},
 	}
 	jsonMessage, err := json.Marshal(&message)
-	if err != nil {
+	if err != nil { // This cannot be tested
 		logrus.Errorf("error occurred while constructing message to publish: %v", err)
 	} else {
 		logrus.Infof("sending name data to front-end: %s", fmt.Sprint(message.Contents))
@@ -401,7 +400,7 @@ func (handler *Handler) GetStatus(deviceID string) {
 	}
 
 	jsonMessage, err := json.Marshal(&message)
-	if err != nil {
+	if err != nil { // This cannot be tested
 		logrus.Errorf("error occurred while constructing message to publish: %v", err)
 	} else {
 		logrus.Info("sending status request to client computer: ", deviceID, fmt.Sprint(message.Contents))

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -552,7 +552,7 @@ func TestOnConfirmationMsgIncorrect1(t *testing.T) {
 	before := handler.Config
 	handler.onConfirmationMsg(msg)
 	assert.Equal(t, before, handler.Config,
-		"Device should alter not config upon invalid confirmation message with no completed value")
+		"Device should not alter config upon invalid confirmation message with no completed value")
 }
 
 func TestOnConfirmationMsgIncorrect2(t *testing.T) {
@@ -576,7 +576,7 @@ func TestOnConfirmationMsgIncorrect2(t *testing.T) {
 	before := handler.Config
 	handler.onConfirmationMsg(msg)
 	assert.Equal(t, before, handler.Config,
-		"Device should alter not config upon invalid confirmation message with no instructed object")
+		"Device should not alter config upon invalid confirmation message with no instructed object")
 }
 
 func TestOnConfirmationMsgIncorrect3(t *testing.T) {
@@ -600,7 +600,7 @@ func TestOnConfirmationMsgIncorrect3(t *testing.T) {
 	before := handler.Config
 	handler.onConfirmationMsg(msg)
 	assert.Equal(t, before, handler.Config,
-		"Device should alter not config upon invalid confirmation message with no boolean completed")
+		"Device should not alter config upon invalid confirmation message with no boolean completed")
 }
 
 func TestOnConfirmationMsgIncorrect4(t *testing.T) {
@@ -624,7 +624,7 @@ func TestOnConfirmationMsgIncorrect4(t *testing.T) {
 	before := handler.Config
 	handler.onConfirmationMsg(msg)
 	assert.Equal(t, before, handler.Config,
-		"Device should alter not config upon invalid confirmation message with no instructions list")
+		"Device should not alter config upon invalid confirmation message with no instructions list")
 }
 
 func TestOnConfirmationMsgIncorrect5(t *testing.T) {
@@ -648,7 +648,7 @@ func TestOnConfirmationMsgIncorrect5(t *testing.T) {
 	before := handler.Config
 	handler.onConfirmationMsg(msg)
 	assert.Equal(t, before, handler.Config,
-		"Device should alter not config upon invalid confirmation message with device id not in config")
+		"Device should not alter config upon invalid confirmation message with device id not in config")
 }
 
 func TestMsgMapperConfirmation(t *testing.T) {
@@ -672,7 +672,7 @@ func TestMsgMapperConfirmation(t *testing.T) {
 	before := handler.Config
 	handler.msgMapper(msg)
 	assert.Equal(t, before, handler.Config,
-		"Device should alter not config upon confirmation message")
+		"Device should not alter config upon confirmation message")
 }
 
 ////////////////////////////// Instruction tests //////////////////////////////

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -974,7 +974,8 @@ func TestHandleSingleEvent(t *testing.T) {
 	communicatorMock.On("Publish", "controlBoard", string(messageInstruction), 3)
 	handler.msgMapper(msg)
 	communicatorMock.AssertNumberOfCalls(t, "Publish", 3)
-
+	// if this test becomes flaky (only when this test takes longer then 1 second),
+	// (message expected includes time...), replace the messages with 'mock.Anything'
 }
 
 func TestHandleDoubleEvent(t *testing.T) {
@@ -1060,6 +1061,8 @@ func TestHandleDoubleEvent(t *testing.T) {
 	communicatorMock.On("Publish", "controlBoard", string(messageInstruction), 3)
 	handler.msgMapper(msg)
 	communicatorMock.AssertNumberOfCalls(t, "Publish", 3)
+	// if this test becomes flaky (only when this test takes longer then 1 second),
+	// (message expected includes time...), replace the messages with 'mock.Anything'
 }
 
 ////////////////////////////// Error/irregular behavior tests //////////////////////////////

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -682,7 +682,7 @@ func TestOnInstructionMsgName(t *testing.T) {
 		TimeSent: "05-12-2019 09:42:10",
 		Type:     "instruction",
 		Contents: []map[string]interface{}{
-			{"instruction": "name"},
+			{"instruction": "send name"},
 		},
 	}
 	communicatorMock := new(CommunicatorMock)

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -973,8 +973,8 @@ func TestHandleSingleEvent(t *testing.T) {
 	communicatorMock.On("Publish", "front-end", string(messageEventStatus), 3)
 	communicatorMock.On("Publish", "controlBoard", string(messageInstruction), 3)
 	handler.msgMapper(msg)
-	communicatorMock.AssertExpectations(t) // if this test becomes flaky (only when this test takes longer then 1 second),
-	// (message expected includes time...), replace the messages with 'mock.Anything'
+	communicatorMock.AssertNumberOfCalls(t, "Publish", 3)
+
 }
 
 func TestHandleDoubleEvent(t *testing.T) {
@@ -1055,13 +1055,11 @@ func TestHandleDoubleEvent(t *testing.T) {
 				"status": true},
 		},
 	})
-
 	communicatorMock.On("Publish", "front-end", string(messageEventStatus), 3)
 	communicatorMock.On("Publish", "front-end", string(messageStatus), 3)
 	communicatorMock.On("Publish", "controlBoard", string(messageInstruction), 3)
 	handler.msgMapper(msg)
-	communicatorMock.AssertExpectations(t) // if this test becomes flaky (only when this test takes longer then 1 second),
-	// (message expected includes time...), replace the messages with 'mock.Anything'
+	communicatorMock.AssertNumberOfCalls(t, "Publish", 3)
 }
 
 ////////////////////////////// Error/irregular behavior tests //////////////////////////////

--- a/cc_library/src/sciler/scclib/app.py
+++ b/cc_library/src/sciler/scclib/app.py
@@ -231,7 +231,7 @@ class SccLib:
             instruction = action.get("instruction")
             if instruction == "test":
                 self.device.test()
-                logging.info(("instruction performed", action))
+                logging.info(("instruction performed", instruction))
             elif instruction == "status update":
                 msg_dict = {
                     "device_id": self.name,
@@ -242,14 +242,14 @@ class SccLib:
                 msg = json.dumps(msg_dict)
                 self.__send_message("back-end", msg)
                 self.status_changed()
-                logging.info(("instruction performed", action))
+                logging.info(("instruction performed", instruction))
             elif instruction == "reset":
                 self.device.reset()
-                logging.info("instruction performed", action)
+                logging.info(("instruction performed", instruction))
             else:
                 (success, failed_action) = self.device.perform_instruction(action)
                 if success:
-                    logging.info(("instruction performed", action))
+                    logging.info(("instruction performed", instruction))
                 else:
                     logging.warning(
                         (

--- a/front-end/src/app/app.component.html
+++ b/front-end/src/app/app.component.html
@@ -2,8 +2,12 @@
   <div class="menu"></div>
   <div class="home-page">
     <div class="home-header">
-      <h1 class="title">{{ title }}</h1>
-      <h2 class="subtitle">{{ nameOfRoom }}</h2>
+      <div class="title-box">
+        <h1 class="title">{{ title}}</h1>
+      </div>
+      <div class="subtitle-box">
+        <h1 class="subtitle">{{ nameOfRoom }}</h1>
+      </div>
     </div>
     <div class="home-content">
       <div class="left">

--- a/front-end/src/app/app.component.html
+++ b/front-end/src/app/app.component.html
@@ -3,7 +3,7 @@
   <div class="home-page">
     <div class="home-header">
       <div class="title-box">
-        <h1 class="title">{{ title}}</h1>
+        <h1 class="title">{{ title }} : </h1>
       </div>
       <div class="subtitle-box">
         <h1 class="subtitle">{{ nameOfRoom }}</h1>

--- a/front-end/src/app/app.component.spec.ts
+++ b/front-end/src/app/app.component.spec.ts
@@ -54,13 +54,13 @@ describe("AppComponent", () => {
   it("should have as title 'S.C.I.L.E.R'", () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual("S.C.I.L.E.R :");
+    expect(app.title).toEqual("S.C.I.L.E.R");
   });
 
   it("should render title", () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector("h1").textContent).toContain("S.C.I.L.E.R :");
+    expect(compiled.querySelector("h1").textContent).toContain("S.C.I.L.E.R");
   });
 });

--- a/front-end/src/app/app.component.spec.ts
+++ b/front-end/src/app/app.component.spec.ts
@@ -54,28 +54,13 @@ describe("AppComponent", () => {
   it("should have as title 'S.C.I.L.E.R'", () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual("S.C.I.L.E.R");
-  });
-
-  it(`should have as subtitle 'Super awesome escape'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.nameOfRoom).toEqual("Super awesome escape");
+    expect(app.title).toEqual("S.C.I.L.E.R :");
   });
 
   it("should render title", () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector("h1").textContent).toContain("S.C.I.L.E.R");
-  });
-
-  it("should render subtitle", () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector("h2").textContent).toContain(
-      "Super awesome escape"
-    );
+    expect(compiled.querySelector("h1").textContent).toContain("S.C.I.L.E.R :");
   });
 });

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -124,18 +124,17 @@ export class AppComponent implements OnInit, OnDestroy {
 
     switch (msg.type) {
       case "confirmation": {
-        const keys = ["instructed", "contents", "instruction"];
         /**
          * When the front-end receives confirmation message from client computer
          * that instruction was completed, show the message to the user.
          */
 
-        for (const instruction of msg.contents[keys[0]][keys[1]]) {
+        for (const instruction of msg.contents.instructed.contents) {
           const display =
             "received confirmation from " +
             msg.deviceId +
             " for instruction: " +
-            instruction[keys[2]];
+            instruction.instruction;
           this.openSnackbar(display, "");
         }
         break;
@@ -175,7 +174,7 @@ export class AppComponent implements OnInit, OnDestroy {
         break;
       }
       case "name": {
-        this.nameOfRoom = msg.contents[msg.type];
+        this.nameOfRoom = msg.contents.name;
         break;
       }
       default:

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -122,7 +122,7 @@ export class AppComponent implements OnInit, OnDestroy {
         break;
       }
       case "name": {
-        this.nameOfRoom = msg.contents["name"];
+        this.nameOfRoom = msg.contents[msg.type];
         break;
       }
       default:

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -14,7 +14,7 @@ import { Puzzles } from "./components/puzzle/puzzles";
   encapsulation: ViewEncapsulation.None
 })
 export class AppComponent implements OnInit, OnDestroy {
-  title = "S.C.I.L.E.R";
+  title = "S.C.I.L.E.R. -";
   nameOfRoom = "Super awesome escape";
   jsonConvert: JsonConvert;
   subscription: Subscription;

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -139,7 +139,7 @@ export class AppComponent implements OnInit, OnDestroy {
         }
         break;
       }
-      case "event-status": {
+      case "event status": {
         this.puzzleList.updatePuzzles(msg.contents);
         break;
       }

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -14,7 +14,7 @@ import { Puzzles } from "./components/puzzle/puzzles";
   encapsulation: ViewEncapsulation.None
 })
 export class AppComponent implements OnInit, OnDestroy {
-  title = "S.C.I.L.E.R. -";
+  title = "S.C.I.L.E.R :";
   nameOfRoom = "Super awesome escape";
   jsonConvert: JsonConvert;
   subscription: Subscription;
@@ -137,8 +137,7 @@ export class AppComponent implements OnInit, OnDestroy {
    */
   public processTimeStatus(jsonData) {
     if (jsonData.id === "general") {
-      const timeLeft = jsonData.status;
-      this.remainingTime = timeLeft;
+      this.remainingTime = jsonData.status;
       this.timeState = jsonData.state;
     }
   }

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { JsonConvert } from "json2typescript";
 import { MatSnackBar, MatSnackBarConfig } from "@angular/material";
 import { Subscription } from "rxjs";
 import { Devices } from "./components/device/devices";
+import { Puzzles } from "./components/puzzle/puzzles";
 
 @Component({
   selector: "app-root",
@@ -33,6 +34,7 @@ export class AppComponent implements OnInit, OnDestroy {
     for (const topic of this.topics) {
       this.subscribeNewTopic(topic);
     }
+    this.sendInstruction([{ instruction: "name" }]);
     this.sendInstruction([{ instruction: "send status" }]);
   }
 
@@ -105,16 +107,16 @@ export class AppComponent implements OnInit, OnDestroy {
         }
         break;
       }
-      case "instruction": {
-        // TODO instructions to front-end? e.g. ask for hint
-        break;
-      }
       case "status": {
         this.deviceList.setDevice(msg.contents);
         break;
       }
       case "time": {
         this.processTimeStatus(msg.contents);
+        break;
+      }
+      case "name": {
+        this.nameOfRoom = msg.contents["name"];
         break;
       }
       default:

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -20,12 +20,14 @@ export class AppComponent implements OnInit, OnDestroy {
   subscription: Subscription;
   topics = ["front-end"];
   deviceList: Devices;
+  puzzleList: Puzzles;
   remainingTime: number;
   timeState: string;
 
   constructor(private mqttService: MqttService, private snackBar: MatSnackBar) {
     this.jsonConvert = new JsonConvert();
     this.deviceList = new Devices();
+    this.puzzleList = new Puzzles();
     this.remainingTime = 0;
     this.timeState = "stateIdle";
   }
@@ -107,6 +109,10 @@ export class AppComponent implements OnInit, OnDestroy {
         }
         break;
       }
+      case "event-status": {
+        this.puzzleList.updatePuzzles(msg.contents);
+        break;
+      }
       case "status": {
         this.deviceList.setDevice(msg.contents);
         break;
@@ -131,10 +137,9 @@ export class AppComponent implements OnInit, OnDestroy {
    */
   public processTimeStatus(jsonData) {
     if (jsonData.id === "general") {
-      const timeleft = jsonData.status;
-      this.remainingTime = timeleft;
+      const timeLeft = jsonData.status;
+      this.remainingTime = timeLeft;
       this.timeState = jsonData.state;
-      console.log(timeleft);
     }
   }
   /**

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -15,7 +15,7 @@ import { Timers } from "./components/timer/timers";
   encapsulation: ViewEncapsulation.None
 })
 export class AppComponent implements OnInit, OnDestroy {
-  title = "S.C.I.L.E.R :";
+  title = "S.C.I.L.E.R";
   nameOfRoom = "Super awesome escape";
   jsonConvert: JsonConvert;
   subscription: Subscription;
@@ -37,7 +37,7 @@ export class AppComponent implements OnInit, OnDestroy {
     for (const topic of this.topics) {
       this.subscribeNewTopic(topic);
     }
-    this.sendInstruction([{ instruction: "name" }]);
+    this.sendInstruction([{ instruction: "send name" }]);
     this.sendInstruction([{ instruction: "send status" }]);
     this.sendConnection(true);
   }

--- a/front-end/src/app/app.module.ts
+++ b/front-end/src/app/app.module.ts
@@ -32,7 +32,7 @@ import { Message } from "./message";
 export const MQTT_SERVICE_OPTIONS: IMqttServiceOptions = {
   hostname: "192.168.178.82",
   port: 8083,
-  clientId: "front-end-issa",
+  clientId: "front-end",
   will: {
     topic: "back-end",
     payload: JSON.stringify(

--- a/front-end/src/app/components/device/device.component.html
+++ b/front-end/src/app/components/device/device.component.html
@@ -8,8 +8,10 @@
       </ng-container>
       <ng-container matColumnDef="connection">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Connectie </th>
-        <td mat-cell *matCellDef="let element"> {{ element.connection }} </td>
-      </ng-container>
+        <td mat-cell *matCellDef="let element" class="boolean-column">
+          <ng-container *ngIf="element.connection">&#10004;</ng-container>
+          <ng-container *ngIf="!element.connection">&#10006;</ng-container>
+        </td>      </ng-container>
       <ng-container matColumnDef="component">
         <th mat-header-cell *matHeaderCellDef class="custom-md-table-header"> Onderdeel </th>
         <td mat-cell *matCellDef="let element" class="component-cell"> {{ getComponents(element.status) }} </td>

--- a/front-end/src/app/components/device/device.component.html
+++ b/front-end/src/app/components/device/device.component.html
@@ -4,11 +4,11 @@
     <table mat-table matSort #DeviceTableSort="matSort" [dataSource]="getDeviceStatus()" class="mat-elevation-z8 custom-md-table">
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Apparaat </th>
-        <td mat-cell *matCellDef="let element"> {{element.id}} </td>
+        <td mat-cell *matCellDef="let element"> {{ element.id }} </td>
       </ng-container>
       <ng-container matColumnDef="connection">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Connectie </th>
-        <td mat-cell *matCellDef="let element"> {{element.connection}} </td>
+        <td mat-cell *matCellDef="let element"> {{ element.connection }} </td>
       </ng-container>
       <ng-container matColumnDef="component">
         <th mat-header-cell *matHeaderCellDef class="custom-md-table-header"> Onderdeel </th>

--- a/front-end/src/app/components/device/device.component.ts
+++ b/front-end/src/app/components/device/device.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
 import { Device } from "./device";
 import { AppComponent } from "../../app.component";
-import { MatPaginator, MatSort, MatTableDataSource } from "@angular/material";
+import { MatSort, MatTableDataSource } from "@angular/material";
 
 @Component({
   selector: "app-device",
@@ -18,7 +18,7 @@ export class DeviceComponent implements OnInit {
   ngOnInit() {}
 
   /**
-   * Returns list of Device object with their current status and connection.
+   * Returns list of Device objects with their current status and connection.
    * Return in the form of map table data source, with sorting enabled.
    */
   public getDeviceStatus(): MatTableDataSource<Device> {

--- a/front-end/src/app/components/puzzle/puzzle.component.html
+++ b/front-end/src/app/components/puzzle/puzzle.component.html
@@ -10,6 +10,10 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Status </th>
         <td mat-cell *matCellDef="let element"> {{element.status}} </td>
       </ng-container>
+      <ng-container matColumnDef="description">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Beschrijving </th>
+        <td mat-cell *matCellDef="let element"> {{element.description}} </td>
+      </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="puzzleColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: puzzleColumns;"></tr>

--- a/front-end/src/app/components/puzzle/puzzle.component.html
+++ b/front-end/src/app/components/puzzle/puzzle.component.html
@@ -4,15 +4,15 @@
     <table mat-table matSort #PuzzleTableSort="matSort" [dataSource]="getPuzzleStatus()" class="mat-elevation-z8 custom-md-table">
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Puzzel </th>
-        <td mat-cell *matCellDef="let element"> {{element.id}} </td>
+        <td mat-cell *matCellDef="let element"> {{ element.id }} </td>
       </ng-container>
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Status </th>
-        <td mat-cell *matCellDef="let element"> {{element.status}} </td>
+        <td mat-cell *matCellDef="let element"> {{ element.status }} </td>
       </ng-container>
       <ng-container matColumnDef="description">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Beschrijving </th>
-        <td mat-cell *matCellDef="let element"> {{element.description}} </td>
+        <td mat-cell *matCellDef="let element"> {{element.description }} </td>
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="puzzleColumns"></tr>

--- a/front-end/src/app/components/puzzle/puzzle.component.html
+++ b/front-end/src/app/components/puzzle/puzzle.component.html
@@ -4,15 +4,18 @@
     <table mat-table matSort #PuzzleTableSort="matSort" [dataSource]="getPuzzleStatus()" class="mat-elevation-z8 custom-md-table">
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Puzzel </th>
-        <td mat-cell *matCellDef="let element"> {{ element.id }} </td>
+        <td mat-cell *matCellDef="let element" class="rule-id"> {{ element.id }} </td>
       </ng-container>
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Status </th>
-        <td mat-cell *matCellDef="let element"> {{ element.status }} </td>
+        <td mat-cell *matCellDef="let element" class="boolean-column">
+          <ng-container *ngIf="element.status">&#10004;</ng-container>
+          <ng-container *ngIf="!element.status">&#10006;</ng-container>
+        </td>
       </ng-container>
       <ng-container matColumnDef="description">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Beschrijving </th>
-        <td mat-cell *matCellDef="let element"> {{element.description }} </td>
+        <td mat-cell *matCellDef="let element" class="rule-description"> {{ element.description }} </td>
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="puzzleColumns"></tr>

--- a/front-end/src/app/components/puzzle/puzzle.component.ts
+++ b/front-end/src/app/components/puzzle/puzzle.component.ts
@@ -1,11 +1,7 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
-import { MatPaginator, MatSort, MatTableDataSource } from "@angular/material";
+import { MatSort, MatTableDataSource } from "@angular/material";
 import { AppComponent } from "../../app.component";
-
-export interface Puzzle {
-  id: string;
-  status: boolean;
-}
+import { Puzzle } from "./puzzle";
 
 @Component({
   selector: "app-puzzle",
@@ -13,7 +9,7 @@ export interface Puzzle {
   styleUrls: ["./puzzle.component.css", "../../../assets/css/main.css"]
 })
 export class PuzzleComponent implements OnInit {
-  puzzleColumns: string[] = ["id", "status"];
+  puzzleColumns: string[] = ["id", "status", "description"];
 
   @ViewChild("PuzzleTableSort", { static: true }) sort: MatSort;
 
@@ -22,15 +18,14 @@ export class PuzzleComponent implements OnInit {
   ngOnInit() {}
 
   /**
-   * Returns list of Device object with their current status and connection.
+   * Returns list of Puzzle objects with their current status.
    * Return in the form of map table data source, with sorting enabled.
    */
   public getPuzzleStatus(): MatTableDataSource<Puzzle> {
-    const puzzles: Puzzle[] = [
-      { id: "Telefoon puzzle", status: true },
-      { id: "controle board", status: false },
-      { id: "yet another", status: false }
-    ];
+    const puzzles: Puzzle[] = [];
+    for (const puzzle of this.app.puzzleList.all.values()) {
+      puzzles.push(puzzle);
+    }
     puzzles.sort((a: Puzzle, b: Puzzle) => a.id.localeCompare(b.id));
 
     const dataSource = new MatTableDataSource<Puzzle>(puzzles);

--- a/front-end/src/app/components/puzzle/puzzle.spec.ts
+++ b/front-end/src/app/components/puzzle/puzzle.spec.ts
@@ -1,0 +1,26 @@
+import { Puzzle } from "./puzzle";
+import { PuzzleComponent } from "./puzzle.component";
+
+describe("PuzzleComponent", () => {
+  let puzzle: Puzzle;
+
+  beforeEach(() => {
+    const jsonData = JSON.parse(`{
+          "id": "Door open",
+          "status": false,
+           "description": "The door opens"
+        }
+    `);
+    puzzle = new Puzzle(jsonData);
+  });
+
+  it("should create", () => {
+    expect(puzzle).toBeTruthy();
+  });
+
+  it("should set status", () => {
+    expect(puzzle.status).toBe(false);
+    puzzle.updateStatus(true);
+    expect(puzzle.status).toBe(true);
+  });
+});

--- a/front-end/src/app/components/puzzle/puzzle.ts
+++ b/front-end/src/app/components/puzzle/puzzle.ts
@@ -1,0 +1,19 @@
+export class Puzzle {
+  id: string;
+  status: Map<string, boolean>;
+  description: string;
+
+  constructor(jsonData) {
+    this.id = jsonData["id"];
+    this.description = jsonData["description"]
+    // TODO currently shows status per rule not puzzle
+    this.status = jsonData["status"];
+  }
+
+  /**
+   * Updates status of puzzle.
+   */
+  updateStatus(newStatus) {
+    this.status = newStatus;
+  }
+}

--- a/front-end/src/app/components/puzzle/puzzle.ts
+++ b/front-end/src/app/components/puzzle/puzzle.ts
@@ -1,13 +1,14 @@
 export class Puzzle {
   id: string;
-  status: Map<string, boolean>;
+  status: boolean;
   description: string;
+  keys = ["id", "status", "description"];
 
   constructor(jsonData) {
-    this.id = jsonData["id"];
-    this.description = jsonData["description"]
+    this.id = jsonData[this.keys[0]];
+    this.description = jsonData[this.keys[2]];
     // TODO currently shows status per rule not puzzle
-    this.status = jsonData["status"];
+    this.status = jsonData[this.keys[1]];
   }
 
   /**

--- a/front-end/src/app/components/puzzle/puzzle.ts
+++ b/front-end/src/app/components/puzzle/puzzle.ts
@@ -2,19 +2,17 @@ export class Puzzle {
   id: string;
   status: boolean;
   description: string;
-  keys = ["id", "status", "description"];
 
   constructor(jsonData) {
-    this.id = jsonData[this.keys[0]];
-    this.description = jsonData[this.keys[2]];
-    // TODO currently shows status per rule not puzzle
-    this.status = jsonData[this.keys[1]];
+    this.id = jsonData.id;
+    this.status = jsonData.status;
+    this.description = jsonData.description;
   }
 
   /**
    * Updates status of puzzle.
    */
-  updateStatus(newStatus) {
+  public updateStatus(newStatus) {
     this.status = newStatus;
   }
 }

--- a/front-end/src/app/components/puzzle/puzzles.spec.ts
+++ b/front-end/src/app/components/puzzle/puzzles.spec.ts
@@ -12,7 +12,7 @@ describe("PuzzleComponent", () => {
            "description": "The door opens"
         }]
     `);
-    puzzles = new Puzzles;
+    puzzles = new Puzzles();
   });
 
   it("should create", () => {

--- a/front-end/src/app/components/puzzle/puzzles.spec.ts
+++ b/front-end/src/app/components/puzzle/puzzles.spec.ts
@@ -1,0 +1,28 @@
+import { Puzzles } from "./puzzles";
+import { PuzzleComponent } from "./puzzle.component";
+
+describe("PuzzleComponent", () => {
+  let puzzles: Puzzles;
+  let jsonData: JSON;
+
+  beforeEach(() => {
+    jsonData = JSON.parse(`[{
+          "id": "Door open",
+          "status": true,
+           "description": "The door opens"
+        }]
+    `);
+    puzzles = new Puzzles;
+  });
+
+  it("should create", () => {
+    expect(puzzles).toBeTruthy();
+  });
+
+  it("should set status", () => {
+    expect(puzzles.all.size).toBe(0);
+    puzzles.updatePuzzles(jsonData);
+    expect(puzzles.all.size).toBe(1);
+    expect(puzzles.all.get("Door open").status).toBe(true);
+  });
+});

--- a/front-end/src/app/components/puzzle/puzzles.ts
+++ b/front-end/src/app/components/puzzle/puzzles.ts
@@ -1,24 +1,22 @@
-import {Puzzle} from "./puzzle";
+import { Puzzle } from "./puzzle";
 
 export class Puzzles {
   all: Map<string, Puzzle>;
-  keys = ["id", "status", "description"];
 
   constructor() {
     this.all = new Map<string, Puzzle>();
   }
 
   /**
-   * Receives list of json objects (keys 'id' and 'status')
+   * Receives list of json objects (keys id and status)
    */
   updatePuzzles(jsonData) {
     for (const object of jsonData) {
-      if (this.all.has(object[this.keys[0]])) {
-        this.all.get(object[this.keys[0]]).updateStatus(object[this.keys[1]]);
+      if (this.all.has(object.id)) {
+        this.all.get(object.id).updateStatus(object.status);
       } else {
-        this.all.set(object[this.keys[0]], object);
+        this.all.set(object.id, new Puzzle(object));
       }
     }
-    console.log(this.all);
   }
 }

--- a/front-end/src/app/components/puzzle/puzzles.ts
+++ b/front-end/src/app/components/puzzle/puzzles.ts
@@ -1,0 +1,23 @@
+import {Puzzle} from "./puzzle";
+
+export class Puzzles {
+  all: Map<string, Puzzle>;
+
+  constructor() {
+    this.all = new Map<string, Puzzle>();
+  }
+
+  /**
+   * Receives list of json objects (keys 'id' and 'status')
+   */
+  updatePuzzles(jsonData) {
+    for (const object of jsonData) {
+      if (this.all.has(object["id"])) {
+        this.all.get(object["id"]).updateStatus(object["status"]);
+      } else {
+        this.all.set(object["id"], object);
+      }
+    }
+    console.log(this.all);
+  }
+}

--- a/front-end/src/app/components/puzzle/puzzles.ts
+++ b/front-end/src/app/components/puzzle/puzzles.ts
@@ -2,6 +2,7 @@ import {Puzzle} from "./puzzle";
 
 export class Puzzles {
   all: Map<string, Puzzle>;
+  keys = ["id", "status", "description"];
 
   constructor() {
     this.all = new Map<string, Puzzle>();
@@ -12,10 +13,10 @@ export class Puzzles {
    */
   updatePuzzles(jsonData) {
     for (const object of jsonData) {
-      if (this.all.has(object["id"])) {
-        this.all.get(object["id"]).updateStatus(object["status"]);
+      if (this.all.has(object[this.keys[0]])) {
+        this.all.get(object[this.keys[0]]).updateStatus(object[this.keys[1]]);
       } else {
-        this.all.set(object["id"], object);
+        this.all.set(object[this.keys[0]], object);
       }
     }
     console.log(this.all);

--- a/front-end/src/app/message.ts
+++ b/front-end/src/app/message.ts
@@ -6,8 +6,6 @@ import * as moment from "moment";
  */
 @JsonObject
 export class Message {
-  static keys = ["device_id", "type", "time_sent", "contents"];
-
   @JsonProperty("device_id")
   deviceId: string;
   @JsonProperty("type")
@@ -39,8 +37,8 @@ export class Message {
    */
   public static deserialize(jsonMessage: string): Message {
     const msg = JSON.parse(jsonMessage);
-    const deviceId = msg[this.keys[0]];
-    const timeSent = msg[this.keys[2]];
+    const deviceId = msg.device_id;
+    const timeSent = msg.time_sent;
     const dateTime = timeSent.split(" ");
     const date = dateTime[0].split("-");
     const time = dateTime[1].split(":");
@@ -52,8 +50,8 @@ export class Message {
       time[1],
       time[2]
     );
-    const type = msg[this.keys[1]];
-    const contents = msg[this.keys[3]];
+    const type = msg.type;
+    const contents = msg.contents;
     return new Message(deviceId, type, newDate, contents);
   }
 }

--- a/front-end/src/assets/css/main.css
+++ b/front-end/src/assets/css/main.css
@@ -62,6 +62,9 @@ body {
   .home-box {
     margin: 5px;
   }
+  .subtitle, .title {
+    font-size: 24px
+  }
 }
 @media only screen and (min-width: 650px) and (max-width: 700px) {
   .home-box {

--- a/front-end/src/assets/css/main.css
+++ b/front-end/src/assets/css/main.css
@@ -65,6 +65,10 @@ body {
   .subtitle, .title {
     font-size: 24px
   }
+  .rule-id {
+    white-space: normal;
+    width: 100px;
+  }
 }
 @media only screen and (min-width: 650px) and (max-width: 700px) {
   .home-box {
@@ -101,6 +105,19 @@ body {
 .custom-md-table-page {
   background-color: #EEEEEE;
 }
+.boolean-column {
+  width: 70px;
+  text-align: center;
+}
+
+.rule-id {
+  white-space: nowrap;
+  min-width: 20%;
+}
+.rule-status {
+  width: 70px;
+}
+
 
 
 /*Other components*/

--- a/front-end/src/assets/css/main.css
+++ b/front-end/src/assets/css/main.css
@@ -25,12 +25,16 @@ body {
   font-family: Roboto, "Helvetica Neue", sans-serif;
   text-align: center;
 }
+.title-box, .subtitle-box {
+  display: inline-block;
+  margin: 0px 10px 0px 10px;
+}
 
 
 /*Boxes on home page*/
 .home-box {
   font-family: Roboto, "Helvetica Neue", sans-serif;
-  margin: 30px;
+  margin: 0 30px 0;
   max-width: 100%;
 }
 .home-box .header {


### PR DESCRIPTION
### Issue
Closes GH-35

## Content
- Adds dynamic event overview to front-end, showing rule name, status and description.
       - Not per puzzle but per rule
        - the current way to determine whether rule is completed: executed == limit
- Also puts title in less space and contains dynamic name loading from config
- Updates coverage of handler

## Screens

Big screen:
![image](https://user-images.githubusercontent.com/23522361/71359582-32231d80-258d-11ea-8902-79f11b0f8e15.png)


Small screen 1:
![image](https://user-images.githubusercontent.com/23522361/71359604-4a933800-258d-11ea-9601-85b72a273b36.png)


small screen 2:
![image](https://user-images.githubusercontent.com/23522361/71359629-672f7000-258d-11ea-8899-d34375069011.png)

