### PR TITLE
47 config front end

### DIFF
--- a/back-end/resources/demo_config.json
+++ b/back-end/resources/demo_config.json
@@ -1,336 +1,111 @@
 {
-  "general": {
-    "name": "Demo week 6",
-    "duration": "5m",
-    "host": "192.168.178.82",
-    "port": 1883
-  },
   "cameras": [],
   "devices": [
     {
-      "id": "controlBoard",
       "description": "Control board with three switches, three slides with lights and one main switch.",
+      "id": "controlBoard",
       "input": {
-        "redSwitch": "boolean",
-        "orangeSwitch": "boolean",
         "greenSwitch": "boolean",
+        "mainSwitch": "boolean",
+        "orangeSwitch": "boolean",
+        "redSwitch": "boolean",
         "slider1": "numeric",
         "slider2": "numeric",
-        "slider3": "numeric",
-        "mainSwitch": "boolean"
+        "slider3": "numeric"
       },
       "output": {
         "greenLight1": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         },
         "greenLight2": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         },
         "greenLight3": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         },
         "redLight1": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         },
         "redLight2": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         },
         "redLight3": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         }
       }
     },
     {
-      "id": "display",
       "description": "displays messages",
+      "id": "display",
       "input": {},
       "output": {
         "hint": {
-          "type": "string",
           "instructions": {
             "hint": "string"
-          }
+          },
+          "type": "string"
         }
       }
     },
     {
-      "id": "door",
       "description": "device that controls a door magnet through a relay",
+      "id": "door",
       "input": {},
       "output": {
         "door": {
-          "type": "string",
           "instructions": {
             "open": "boolean"
-          }
+          },
+          "type": "string"
         }
       }
     },
     {
-      "id": "keypad",
       "description": "Keypad with input 4 numbers",
+      "id": "keypad",
       "input": {
         "code": "numeric"
       },
       "output": {}
     }
   ],
-  "timers": [
-    {
-      "id": "timer1",
-      "duration": "10s"
-    },
-    {
-      "id": "timer2",
-      "duration": "5s"
-    },
-    {
-      "id": "timer3",
-      "duration": "1m"
-    },
-    {
-      "id": "timer4",
-      "duration": "1h"
-    },
-    {
-      "id": "timer5",
-      "duration": "20s"
-    },
-    {
-      "id": "timer6",
-      "duration": "5s"
-    }
-  ],
-  "puzzles": [
-    {
-      "name": "puzzel drank",
-      "rules": [
-        {
-          "id": "drank",
-          "description": "Wanneer de rode switch op true staat en de slider 100, dan sturen we een hint met 'puzzle rood opgelost'",
-          "limit": 1,
-          "conditions": {
-            "operator": "AND",
-            "list": [
-              {
-                "type": "device",
-                "type_id": "controlBoard",
-                "constraints": {
-                  "operator": "AND",
-                  "list": [
-                    {
-                      "component_id": "slider1",
-                      "comparison": "lte",
-                      "value": 80
-                    },
-                    {
-                      "component_id": "slider1",
-                      "comparison": "gte",
-                      "value": 10
-                    },
-                    {
-                      "component_id": "slider2",
-                      "comparison": "lte",
-                      "value": 10
-                    },
-                    {
-                      "component_id": "slider2",
-                      "comparison": "gte",
-                      "value": 0
-                    },
-                    {
-                      "component_id": "slider3",
-                      "comparison": "lte",
-                      "value": 100
-                    },
-                    {
-                      "component_id": "slider3",
-                      "comparison": "gte",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "rule",
-                "type_id": "codedeur",
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                }
-              }
-            ]
-          },
-          "actions": [
-            {
-              "type": "device",
-              "type_id": "controlBoard",
-              "message": [
-                {
-                  "component_id": "redLight1",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight1",
-                  "instruction": "turnOnOff",
-                  "value": true
-                },
-                {
-                  "component_id": "redLight2",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight2",
-                  "instruction": "turnOnOff",
-                  "value": true
-                },
-                {
-                  "component_id": "redLight3",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight3",
-                  "instruction": "turnOnOff",
-                  "value": true
-                }
-              ]
-            },
-            {
-              "type": "device",
-              "type_id": "display",
-              "message": [
-                {
-                  "component_id": "hint",
-                  "instruction": "hint",
-                  "value": "We kunnen nu gaan zuipon!"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "hints": [
-        "Zet de schuiven nauwkeurig"
-      ]
-    },
-    {
-      "name": "puzzel keypad to door",
-      "rules": [
-        {
-          "id": "codedeur",
-          "description": "er moet een code gestuurd worden, dan gaat de magneet open",
-          "limit": 1,
-          "conditions": {
-            "operator": "AND",
-            "list": [
-              {
-                "type": "device",
-                "type_id": "keypad",
-                "constraints": {
-                  "operator": "AND",
-                  "list": [
-                    {
-                      "component_id": "code",
-                      "comparison": "eq",
-                      "value": 45
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "rule",
-                "type_id": "start",
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                }
-              }
-            ]
-          },
-          "actions": [
-            {
-              "type": "device",
-              "type_id": "door",
-              "message": [
-                {
-                  "component_id": "door",
-                  "instruction": "open",
-                  "value": false
-                }
-              ]
-            },
-            {
-              "type": "device",
-              "type_id": "display",
-              "message": [
-                {
-                  "component_id": "hint",
-                  "instruction": "hint",
-                  "value": "hoorde ik daar een klik?"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "hints": [
-        "Zet de schuiven nauwkeurig"
-      ]
-    }
-  ],
+  "general": {
+    "duration": "5m",
+    "host": "192.168.178.82",
+    "name": "Demo week 6",
+    "port": 1883
+  },
   "general_events": [
     {
       "name": "Start knop",
       "rules": [
         {
-          "id": "start",
-          "description": "Als het spel start, moeten alle rode leds aan gaan en de groene uit",
-          "limit": 1,
-          "conditions": {
-            "operator": "OR",
-            "list": [
-              {
-                "type": "device",
-                "type_id": "front-end",
-                "constraints": {
-                  "component_id": "start",
-                  "comparison": "gte",
-                  "value": 1
-                }
-              }
-            ]
-          },
           "actions": [
             {
-              "type": "device",
-              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -362,40 +137,59 @@
                   "instruction": "turnOnOff",
                   "value": false
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "controlBoard"
             },
             {
-              "type": "timer",
-              "type_id": "general",
               "message": [
                 {
                   "instruction": "start"
                 }
-              ]
+              ],
+              "type": "timer",
+              "type_id": "general"
             },
             {
-              "type": "device",
-              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "Hoeveel kerstballen hangen er ongeveer in de boom?"
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "display"
             },
             {
-              "type": "device",
-              "type_id": "door",
               "message": [
                 {
                   "component_id": "door",
                   "instruction": "open",
                   "value": true
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "door"
             }
-          ]
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "comparison": "gte",
+                  "component_id": "start",
+                  "value": 1
+                },
+                "type": "device",
+                "type_id": "front-end"
+              }
+            ],
+            "operator": "OR"
+          },
+          "description": "Als het spel start, moeten alle rode leds aan gaan en de groene uit",
+          "id": "start",
+          "limit": 1
         }
       ]
     },
@@ -403,110 +197,110 @@
       "name": "hints",
       "rules": [
         {
-          "id": "hint1",
-          "description": "te laag hint",
-          "limit": 100,
-          "conditions": {
-            "operator": "AND",
-            "list": [
-              {
-                "type": "device",
-                "type_id": "keypad",
-                "constraints": {
-                  "operator": "AND",
-                  "list": [
-                    {
-                      "component_id": "code",
-                      "comparison": "lte",
-                      "value": 44
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "rule",
-                "type_id": "start",
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                }
-              },
-              {
-                "type": "rule",
-                "type_id": "codedeur",
-                "constraints": {
-                  "comparison": "lte",
-                  "value": 2
-                }
-              }
-            ]
-          },
           "actions": [
             {
-              "type": "device",
-              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "dat is te laag"
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "display"
             }
-          ]
-        },
-        {
-          "id": "hint2",
-          "description": "te hoog hint",
-          "limit": 100,
+          ],
           "conditions": {
-            "operator": "AND",
             "list": [
               {
-                "type": "device",
-                "type_id": "keypad",
                 "constraints": {
-                  "operator": "AND",
                   "list": [
                     {
+                      "comparison": "lte",
                       "component_id": "code",
-                      "comparison": "gte",
-                      "value": 46
+                      "value": 44
                     }
-                  ]
-                }
+                  ],
+                  "operator": "AND"
+                },
+                "type": "device",
+                "type_id": "keypad"
               },
               {
-                "type": "rule",
-                "type_id": "start",
                 "constraints": {
                   "comparison": "gte",
                   "value": 1
-                }
+                },
+                "type": "rule",
+                "type_id": "start"
               },
               {
-                "type": "rule",
-                "type_id": "codedeur",
                 "constraints": {
                   "comparison": "lte",
                   "value": 2
-                }
+                },
+                "type": "rule",
+                "type_id": "codedeur"
               }
-            ]
+            ],
+            "operator": "AND"
           },
+          "description": "te laag hint",
+          "id": "hint1",
+          "limit": 100
+        },
+        {
           "actions": [
             {
-              "type": "device",
-              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "dat is te hoog"
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "display"
             }
-          ]
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "list": [
+                    {
+                      "comparison": "gte",
+                      "component_id": "code",
+                      "value": 46
+                    }
+                  ],
+                  "operator": "AND"
+                },
+                "type": "device",
+                "type_id": "keypad"
+              },
+              {
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "start"
+              },
+              {
+                "constraints": {
+                  "comparison": "lte",
+                  "value": 2
+                },
+                "type": "rule",
+                "type_id": "codedeur"
+              }
+            ],
+            "operator": "AND"
+          },
+          "description": "te hoog hint",
+          "id": "hint2",
+          "limit": 100
         }
       ]
     },
@@ -514,32 +308,19 @@
       "name": "Stop Time up",
       "rules": [
         {
-          "id": "time up",
-          "description": "Na de duration van het spel faalt de groep",
-          "limit": 1,
-          "conditions": {
-            "type": "timer",
-            "type_id": "general",
-            "constraints": {
-              "comparison": "eq",
-              "value": true
-            }
-          },
           "actions": [
             {
-              "type": "device",
-              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "Je tijd is voorbij!"
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "display"
             },
             {
-              "type": "device",
-              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -571,9 +352,22 @@
                   "instruction": "turnOnOff",
                   "value": true
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "controlBoard"
             }
-          ]
+          ],
+          "conditions": {
+            "constraints": {
+              "comparison": "eq",
+              "value": true
+            },
+            "type": "timer",
+            "type_id": "general"
+          },
+          "description": "Na de duration van het spel faalt de groep",
+          "id": "time up",
+          "limit": 1
         }
       ]
     },
@@ -581,52 +375,52 @@
       "name": "Stop Done",
       "rules": [
         {
-          "id": "Puzzles done",
-          "description": "Puzzles zijn opgelost dus time stop",
-          "limit": 1,
-          "conditions": {
-            "operator": "AND",
-            "list": [
-              {
-                "type": "rule",
-                "type_id": "drank",
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                }
-              },
-              {
-                "type": "rule",
-                "type_id": "codedeur",
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                }
-              }
-            ]
-          },
           "actions": [
             {
-              "type": "device",
-              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "Puzzle opgelost!"
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "display"
             },
             {
-              "type": "timer",
-              "type_id": "general",
               "message": [
                 {
                   "instruction": "pause"
                 }
-              ]
+              ],
+              "type": "timer",
+              "type_id": "general"
             }
-          ]
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "drank"
+              },
+              {
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "codedeur"
+              }
+            ],
+            "operator": "AND"
+          },
+          "description": "Puzzles zijn opgelost dus time stop",
+          "id": "Puzzles done",
+          "limit": 1
         }
       ]
     },
@@ -634,27 +428,8 @@
       "name": "Stop knop",
       "rules": [
         {
-          "id": "stop",
-          "description": "Als het spel stopt, moeten alle lichten uitgaan",
-          "limit": 1,
-          "conditions": {
-            "operator": "OR",
-            "list": [
-              {
-                "type": "device",
-                "type_id": "front-end",
-                "constraints": {
-                  "component_id": "stop",
-                  "comparison": "eq",
-                  "value": 1
-                }
-              }
-            ]
-          },
           "actions": [
             {
-              "type": "device",
-              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -686,31 +461,256 @@
                   "instruction": "turnOnOff",
                   "value": false
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "controlBoard"
             },
             {
-              "type": "device",
-              "type_id": "door",
               "message": [
                 {
                   "component_id": "door",
                   "instruction": "open",
                   "value": false
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "door"
             },
             {
-              "type": "timer",
-              "type_id": "general",
               "message": [
                 {
                   "instruction": "pause"
                 }
-              ]
+              ],
+              "type": "timer",
+              "type_id": "general"
             }
-          ]
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "comparison": "eq",
+                  "component_id": "stop",
+                  "value": 1
+                },
+                "type": "device",
+                "type_id": "front-end"
+              }
+            ],
+            "operator": "OR"
+          },
+          "description": "Als het spel stopt, moeten alle lichten uitgaan",
+          "id": "stop",
+          "limit": 1
         }
       ]
+    }
+  ],
+  "puzzles": [
+    {
+      "hints": [
+        "Zet de schuiven nauwkeurig"
+      ],
+      "name": "puzzel drank",
+      "rules": [
+        {
+          "actions": [
+            {
+              "message": [
+                {
+                  "component_id": "redLight1",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight1",
+                  "instruction": "turnOnOff",
+                  "value": true
+                },
+                {
+                  "component_id": "redLight2",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight2",
+                  "instruction": "turnOnOff",
+                  "value": true
+                },
+                {
+                  "component_id": "redLight3",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight3",
+                  "instruction": "turnOnOff",
+                  "value": true
+                }
+              ],
+              "type": "device",
+              "type_id": "controlBoard"
+            },
+            {
+              "message": [
+                {
+                  "component_id": "hint",
+                  "instruction": "hint",
+                  "value": "We kunnen nu gaan zuipon!"
+                }
+              ],
+              "type": "device",
+              "type_id": "display"
+            }
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "list": [
+                    {
+                      "comparison": "lte",
+                      "component_id": "slider1",
+                      "value": 80
+                    },
+                    {
+                      "comparison": "gte",
+                      "component_id": "slider1",
+                      "value": 10
+                    },
+                    {
+                      "comparison": "lte",
+                      "component_id": "slider2",
+                      "value": 10
+                    },
+                    {
+                      "comparison": "gte",
+                      "component_id": "slider2",
+                      "value": 0
+                    },
+                    {
+                      "comparison": "lte",
+                      "component_id": "slider3",
+                      "value": 100
+                    },
+                    {
+                      "comparison": "gte",
+                      "component_id": "slider3",
+                      "value": 80
+                    }
+                  ],
+                  "operator": "AND"
+                },
+                "type": "device",
+                "type_id": "controlBoard"
+              },
+              {
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "codedeur"
+              }
+            ],
+            "operator": "AND"
+          },
+          "description": "Wanneer de rode switch op true staat en de slider 100, dan sturen we een hint met 'puzzle rood opgelost'",
+          "id": "drank",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "hints": [
+        "Zet de schuiven nauwkeurig"
+      ],
+      "name": "puzzel keypad to door",
+      "rules": [
+        {
+          "actions": [
+            {
+              "message": [
+                {
+                  "component_id": "door",
+                  "instruction": "open",
+                  "value": false
+                }
+              ],
+              "type": "device",
+              "type_id": "door"
+            },
+            {
+              "message": [
+                {
+                  "component_id": "hint",
+                  "instruction": "hint",
+                  "value": "hoorde ik daar een klik?"
+                }
+              ],
+              "type": "device",
+              "type_id": "display"
+            }
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "list": [
+                    {
+                      "comparison": "eq",
+                      "component_id": "code",
+                      "value": 45
+                    }
+                  ],
+                  "operator": "AND"
+                },
+                "type": "device",
+                "type_id": "keypad"
+              },
+              {
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "start"
+              }
+            ],
+            "operator": "AND"
+          },
+          "description": "er moet een code gestuurd worden, dan gaat de magneet open",
+          "id": "codedeur",
+          "limit": 1
+        }
+      ]
+    }
+  ],
+  "timers": [
+    {
+      "duration": "10s",
+      "id": "timer1"
+    },
+    {
+      "duration": "5s",
+      "id": "timer2"
+    },
+    {
+      "duration": "1m",
+      "id": "timer3"
+    },
+    {
+      "duration": "1h",
+      "id": "timer4"
+    },
+    {
+      "duration": "20s",
+      "id": "timer5"
+    },
+    {
+      "duration": "5s",
+      "id": "timer6"
     }
   ]
 }

--- a/back-end/resources/demo_config.json
+++ b/back-end/resources/demo_config.json
@@ -1,111 +1,336 @@
 {
+  "general": {
+    "name": "Demo week 6",
+    "duration": "5m",
+    "host": "192.168.178.82",
+    "port": 1883
+  },
   "cameras": [],
   "devices": [
     {
-      "description": "Control board with three switches, three slides with lights and one main switch.",
       "id": "controlBoard",
+      "description": "Control board with three switches, three slides with lights and one main switch.",
       "input": {
-        "greenSwitch": "boolean",
-        "mainSwitch": "boolean",
-        "orangeSwitch": "boolean",
         "redSwitch": "boolean",
+        "orangeSwitch": "boolean",
+        "greenSwitch": "boolean",
         "slider1": "numeric",
         "slider2": "numeric",
-        "slider3": "numeric"
+        "slider3": "numeric",
+        "mainSwitch": "boolean"
       },
       "output": {
         "greenLight1": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         },
         "greenLight2": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         },
         "greenLight3": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         },
         "redLight1": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         },
         "redLight2": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         },
         "redLight3": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         }
       }
     },
     {
-      "description": "displays messages",
       "id": "display",
+      "description": "displays messages",
       "input": {},
       "output": {
         "hint": {
+          "type": "string",
           "instructions": {
             "hint": "string"
-          },
-          "type": "string"
+          }
         }
       }
     },
     {
-      "description": "device that controls a door magnet through a relay",
       "id": "door",
+      "description": "device that controls a door magnet through a relay",
       "input": {},
       "output": {
         "door": {
+          "type": "string",
           "instructions": {
             "open": "boolean"
-          },
-          "type": "string"
+          }
         }
       }
     },
     {
-      "description": "Keypad with input 4 numbers",
       "id": "keypad",
+      "description": "Keypad with input 4 numbers",
       "input": {
         "code": "numeric"
       },
       "output": {}
     }
   ],
-  "general": {
-    "duration": "5m",
-    "host": "192.168.178.82",
-    "name": "Demo week 6",
-    "port": 1883
-  },
+  "timers": [
+    {
+      "id": "timer1",
+      "duration": "10s"
+    },
+    {
+      "id": "timer2",
+      "duration": "5s"
+    },
+    {
+      "id": "timer3",
+      "duration": "1m"
+    },
+    {
+      "id": "timer4",
+      "duration": "1h"
+    },
+    {
+      "id": "timer5",
+      "duration": "20s"
+    },
+    {
+      "id": "timer6",
+      "duration": "5s"
+    }
+  ],
+  "puzzles": [
+    {
+      "name": "puzzel drank",
+      "rules": [
+        {
+          "id": "drank",
+          "description": "Wanneer de rode switch op true staat en de slider 100, dan sturen we een hint met 'puzzle rood opgelost'",
+          "limit": 1,
+          "conditions": {
+            "operator": "AND",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "controlBoard",
+                "constraints": {
+                  "operator": "AND",
+                  "list": [
+                    {
+                      "component_id": "slider1",
+                      "comparison": "lte",
+                      "value": 80
+                    },
+                    {
+                      "component_id": "slider1",
+                      "comparison": "gte",
+                      "value": 10
+                    },
+                    {
+                      "component_id": "slider2",
+                      "comparison": "lte",
+                      "value": 10
+                    },
+                    {
+                      "component_id": "slider2",
+                      "comparison": "gte",
+                      "value": 0
+                    },
+                    {
+                      "component_id": "slider3",
+                      "comparison": "lte",
+                      "value": 100
+                    },
+                    {
+                      "component_id": "slider3",
+                      "comparison": "gte",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "codedeur",
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                }
+              }
+            ]
+          },
+          "actions": [
+            {
+              "type": "device",
+              "type_id": "controlBoard",
+              "message": [
+                {
+                  "component_id": "redLight1",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight1",
+                  "instruction": "turnOnOff",
+                  "value": true
+                },
+                {
+                  "component_id": "redLight2",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight2",
+                  "instruction": "turnOnOff",
+                  "value": true
+                },
+                {
+                  "component_id": "redLight3",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight3",
+                  "instruction": "turnOnOff",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "type": "device",
+              "type_id": "display",
+              "message": [
+                {
+                  "component_id": "hint",
+                  "instruction": "hint",
+                  "value": "We kunnen nu gaan zuipon!"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "hints": [
+        "Zet de schuiven nauwkeurig"
+      ]
+    },
+    {
+      "name": "puzzel keypad to door",
+      "rules": [
+        {
+          "id": "codedeur",
+          "description": "er moet een code gestuurd worden, dan gaat de magneet open",
+          "limit": 1,
+          "conditions": {
+            "operator": "AND",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "keypad",
+                "constraints": {
+                  "operator": "AND",
+                  "list": [
+                    {
+                      "component_id": "code",
+                      "comparison": "eq",
+                      "value": 45
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "start",
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                }
+              }
+            ]
+          },
+          "actions": [
+            {
+              "type": "device",
+              "type_id": "door",
+              "message": [
+                {
+                  "component_id": "door",
+                  "instruction": "open",
+                  "value": false
+                }
+              ]
+            },
+            {
+              "type": "device",
+              "type_id": "display",
+              "message": [
+                {
+                  "component_id": "hint",
+                  "instruction": "hint",
+                  "value": "hoorde ik daar een klik?"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "hints": [
+        "Zet de schuiven nauwkeurig"
+      ]
+    }
+  ],
   "general_events": [
     {
       "name": "Start knop",
       "rules": [
         {
+          "id": "start",
+          "description": "Als het spel start, moeten alle rode leds aan gaan en de groene uit",
+          "limit": 1,
+          "conditions": {
+            "operator": "OR",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "front-end",
+                "constraints": {
+                  "component_id": "start",
+                  "comparison": "gte",
+                  "value": 1
+                }
+              }
+            ]
+          },
           "actions": [
             {
+              "type": "device",
+              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -137,59 +362,40 @@
                   "instruction": "turnOnOff",
                   "value": false
                 }
-              ],
-              "type": "device",
-              "type_id": "controlBoard"
+              ]
             },
             {
+              "type": "timer",
+              "type_id": "general",
               "message": [
                 {
                   "instruction": "start"
                 }
-              ],
-              "type": "timer",
-              "type_id": "general"
+              ]
             },
             {
+              "type": "device",
+              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "Hoeveel kerstballen hangen er ongeveer in de boom?"
                 }
-              ],
-              "type": "device",
-              "type_id": "display"
+              ]
             },
             {
+              "type": "device",
+              "type_id": "door",
               "message": [
                 {
                   "component_id": "door",
                   "instruction": "open",
                   "value": true
                 }
-              ],
-              "type": "device",
-              "type_id": "door"
+              ]
             }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "comparison": "gte",
-                  "component_id": "start",
-                  "value": 1
-                },
-                "type": "device",
-                "type_id": "front-end"
-              }
-            ],
-            "operator": "OR"
-          },
-          "description": "Als het spel start, moeten alle rode leds aan gaan en de groene uit",
-          "id": "start",
-          "limit": 1
+          ]
         }
       ]
     },
@@ -197,110 +403,110 @@
       "name": "hints",
       "rules": [
         {
+          "id": "hint1",
+          "description": "te laag hint",
+          "limit": 100,
+          "conditions": {
+            "operator": "AND",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "keypad",
+                "constraints": {
+                  "operator": "AND",
+                  "list": [
+                    {
+                      "component_id": "code",
+                      "comparison": "lte",
+                      "value": 44
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "start",
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "codedeur",
+                "constraints": {
+                  "comparison": "lte",
+                  "value": 2
+                }
+              }
+            ]
+          },
           "actions": [
             {
+              "type": "device",
+              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "dat is te laag"
                 }
-              ],
-              "type": "device",
-              "type_id": "display"
+              ]
             }
-          ],
+          ]
+        },
+        {
+          "id": "hint2",
+          "description": "te hoog hint",
+          "limit": 100,
           "conditions": {
+            "operator": "AND",
             "list": [
               {
+                "type": "device",
+                "type_id": "keypad",
                 "constraints": {
+                  "operator": "AND",
                   "list": [
                     {
-                      "comparison": "lte",
                       "component_id": "code",
-                      "value": 44
+                      "comparison": "gte",
+                      "value": 46
                     }
-                  ],
-                  "operator": "AND"
-                },
-                "type": "device",
-                "type_id": "keypad"
+                  ]
+                }
               },
               {
+                "type": "rule",
+                "type_id": "start",
                 "constraints": {
                   "comparison": "gte",
                   "value": 1
-                },
-                "type": "rule",
-                "type_id": "start"
+                }
               },
               {
+                "type": "rule",
+                "type_id": "codedeur",
                 "constraints": {
                   "comparison": "lte",
                   "value": 2
-                },
-                "type": "rule",
-                "type_id": "codedeur"
+                }
               }
-            ],
-            "operator": "AND"
+            ]
           },
-          "description": "te laag hint",
-          "id": "hint1",
-          "limit": 100
-        },
-        {
           "actions": [
             {
+              "type": "device",
+              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "dat is te hoog"
                 }
-              ],
-              "type": "device",
-              "type_id": "display"
+              ]
             }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "list": [
-                    {
-                      "comparison": "gte",
-                      "component_id": "code",
-                      "value": 46
-                    }
-                  ],
-                  "operator": "AND"
-                },
-                "type": "device",
-                "type_id": "keypad"
-              },
-              {
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "start"
-              },
-              {
-                "constraints": {
-                  "comparison": "lte",
-                  "value": 2
-                },
-                "type": "rule",
-                "type_id": "codedeur"
-              }
-            ],
-            "operator": "AND"
-          },
-          "description": "te hoog hint",
-          "id": "hint2",
-          "limit": 100
+          ]
         }
       ]
     },
@@ -308,19 +514,32 @@
       "name": "Stop Time up",
       "rules": [
         {
+          "id": "time up",
+          "description": "Na de duration van het spel faalt de groep",
+          "limit": 1,
+          "conditions": {
+            "type": "timer",
+            "type_id": "general",
+            "constraints": {
+              "comparison": "eq",
+              "value": true
+            }
+          },
           "actions": [
             {
+              "type": "device",
+              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "Je tijd is voorbij!"
                 }
-              ],
-              "type": "device",
-              "type_id": "display"
+              ]
             },
             {
+              "type": "device",
+              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -352,22 +571,9 @@
                   "instruction": "turnOnOff",
                   "value": true
                 }
-              ],
-              "type": "device",
-              "type_id": "controlBoard"
+              ]
             }
-          ],
-          "conditions": {
-            "constraints": {
-              "comparison": "eq",
-              "value": true
-            },
-            "type": "timer",
-            "type_id": "general"
-          },
-          "description": "Na de duration van het spel faalt de groep",
-          "id": "time up",
-          "limit": 1
+          ]
         }
       ]
     },
@@ -375,52 +581,52 @@
       "name": "Stop Done",
       "rules": [
         {
+          "id": "Puzzles done",
+          "description": "Puzzles zijn opgelost dus time stop",
+          "limit": 1,
+          "conditions": {
+            "operator": "AND",
+            "list": [
+              {
+                "type": "rule",
+                "type_id": "drank",
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "codedeur",
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                }
+              }
+            ]
+          },
           "actions": [
             {
+              "type": "device",
+              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "Puzzle opgelost!"
                 }
-              ],
-              "type": "device",
-              "type_id": "display"
+              ]
             },
             {
+              "type": "timer",
+              "type_id": "general",
               "message": [
                 {
                   "instruction": "pause"
                 }
-              ],
-              "type": "timer",
-              "type_id": "general"
+              ]
             }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "drank"
-              },
-              {
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "codedeur"
-              }
-            ],
-            "operator": "AND"
-          },
-          "description": "Puzzles zijn opgelost dus time stop",
-          "id": "Puzzles done",
-          "limit": 1
+          ]
         }
       ]
     },
@@ -428,8 +634,27 @@
       "name": "Stop knop",
       "rules": [
         {
+          "id": "stop",
+          "description": "Als het spel stopt, moeten alle lichten uitgaan",
+          "limit": 1,
+          "conditions": {
+            "operator": "OR",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "front-end",
+                "constraints": {
+                  "component_id": "stop",
+                  "comparison": "eq",
+                  "value": 1
+                }
+              }
+            ]
+          },
           "actions": [
             {
+              "type": "device",
+              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -461,256 +686,31 @@
                   "instruction": "turnOnOff",
                   "value": false
                 }
-              ],
-              "type": "device",
-              "type_id": "controlBoard"
+              ]
             },
             {
+              "type": "device",
+              "type_id": "door",
               "message": [
                 {
                   "component_id": "door",
                   "instruction": "open",
                   "value": false
                 }
-              ],
-              "type": "device",
-              "type_id": "door"
+              ]
             },
             {
+              "type": "timer",
+              "type_id": "general",
               "message": [
                 {
                   "instruction": "pause"
                 }
-              ],
-              "type": "timer",
-              "type_id": "general"
+              ]
             }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "comparison": "eq",
-                  "component_id": "stop",
-                  "value": 1
-                },
-                "type": "device",
-                "type_id": "front-end"
-              }
-            ],
-            "operator": "OR"
-          },
-          "description": "Als het spel stopt, moeten alle lichten uitgaan",
-          "id": "stop",
-          "limit": 1
+          ]
         }
       ]
-    }
-  ],
-  "puzzles": [
-    {
-      "hints": [
-        "Zet de schuiven nauwkeurig"
-      ],
-      "name": "puzzel drank",
-      "rules": [
-        {
-          "actions": [
-            {
-              "message": [
-                {
-                  "component_id": "redLight1",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight1",
-                  "instruction": "turnOnOff",
-                  "value": true
-                },
-                {
-                  "component_id": "redLight2",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight2",
-                  "instruction": "turnOnOff",
-                  "value": true
-                },
-                {
-                  "component_id": "redLight3",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight3",
-                  "instruction": "turnOnOff",
-                  "value": true
-                }
-              ],
-              "type": "device",
-              "type_id": "controlBoard"
-            },
-            {
-              "message": [
-                {
-                  "component_id": "hint",
-                  "instruction": "hint",
-                  "value": "We kunnen nu gaan zuipon!"
-                }
-              ],
-              "type": "device",
-              "type_id": "display"
-            }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "list": [
-                    {
-                      "comparison": "lte",
-                      "component_id": "slider1",
-                      "value": 80
-                    },
-                    {
-                      "comparison": "gte",
-                      "component_id": "slider1",
-                      "value": 10
-                    },
-                    {
-                      "comparison": "lte",
-                      "component_id": "slider2",
-                      "value": 10
-                    },
-                    {
-                      "comparison": "gte",
-                      "component_id": "slider2",
-                      "value": 0
-                    },
-                    {
-                      "comparison": "lte",
-                      "component_id": "slider3",
-                      "value": 100
-                    },
-                    {
-                      "comparison": "gte",
-                      "component_id": "slider3",
-                      "value": 80
-                    }
-                  ],
-                  "operator": "AND"
-                },
-                "type": "device",
-                "type_id": "controlBoard"
-              },
-              {
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "codedeur"
-              }
-            ],
-            "operator": "AND"
-          },
-          "description": "Wanneer de rode switch op true staat en de slider 100, dan sturen we een hint met 'puzzle rood opgelost'",
-          "id": "drank",
-          "limit": 1
-        }
-      ]
-    },
-    {
-      "hints": [
-        "Zet de schuiven nauwkeurig"
-      ],
-      "name": "puzzel keypad to door",
-      "rules": [
-        {
-          "actions": [
-            {
-              "message": [
-                {
-                  "component_id": "door",
-                  "instruction": "open",
-                  "value": false
-                }
-              ],
-              "type": "device",
-              "type_id": "door"
-            },
-            {
-              "message": [
-                {
-                  "component_id": "hint",
-                  "instruction": "hint",
-                  "value": "hoorde ik daar een klik?"
-                }
-              ],
-              "type": "device",
-              "type_id": "display"
-            }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "list": [
-                    {
-                      "comparison": "eq",
-                      "component_id": "code",
-                      "value": 45
-                    }
-                  ],
-                  "operator": "AND"
-                },
-                "type": "device",
-                "type_id": "keypad"
-              },
-              {
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "start"
-              }
-            ],
-            "operator": "AND"
-          },
-          "description": "er moet een code gestuurd worden, dan gaat de magneet open",
-          "id": "codedeur",
-          "limit": 1
-        }
-      ]
-    }
-  ],
-  "timers": [
-    {
-      "duration": "10s",
-      "id": "timer1"
-    },
-    {
-      "duration": "5s",
-      "id": "timer2"
-    },
-    {
-      "duration": "1m",
-      "id": "timer3"
-    },
-    {
-      "duration": "1h",
-      "id": "timer4"
-    },
-    {
-      "duration": "20s",
-      "id": "timer5"
-    },
-    {
-      "duration": "5s",
-      "id": "timer6"
     }
   ]
 }

--- a/back-end/resources/room_config.json
+++ b/back-end/resources/room_config.json
@@ -2,7 +2,7 @@
   "general": {
     "name": "Escape X",
     "duration": "30m",
-    "host": "localhost",
+    "host": "192.168.178.82",
     "port": 1883
   },
    "cameras": [

--- a/back-end/resources/room_config.json
+++ b/back-end/resources/room_config.json
@@ -2,7 +2,7 @@
   "general": {
     "name": "Escape X",
     "duration": "30m",
-    "host": "192.168.178.82",
+    "host": "localhost",
     "port": 1883
   },
    "cameras": [

--- a/back-end/resources/room_config.json
+++ b/back-end/resources/room_config.json
@@ -1,400 +1,124 @@
 {
-  "general": {
-    "name": "Escape X",
-    "duration": "30m",
-    "host": "192.168.178.82",
-    "port": 1883
-  },
-   "cameras": [
-     {"name": "camera1", "link": "https://raccoon.games"},
-     {"name": "camera2", "link": "https://debrouwerij.io"},
-     {"name": "muppets", "link": "https://www.youtube.com/embed/tgbNymZ7vqY"}
+  "cameras": [
+    {
+      "link": "https://raccoon.games",
+      "name": "camera1"
+    },
+    {
+      "link": "https://debrouwerij.io",
+      "name": "camera2"
+    },
+    {
+      "link": "https://www.youtube.com/embed/tgbNymZ7vqY",
+      "name": "muppets"
+    }
   ],
   "devices": [
     {
-      "id": "controlBoard",
       "description": "Control board with three switches, three slides with lights and one main switch.",
+      "id": "controlBoard",
       "input": {
-        "redSwitch": "boolean",
-        "orangeSwitch": "boolean",
         "greenSwitch": "boolean",
+        "mainSwitch": "boolean",
+        "orangeSwitch": "boolean",
+        "redSwitch": "boolean",
         "slider1": "numeric",
         "slider2": "numeric",
-        "slider3": "numeric",
-        "mainSwitch": "boolean"
+        "slider3": "numeric"
       },
       "output": {
         "greenLight1": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         },
         "greenLight2": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         },
         "greenLight3": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         },
         "redLight1": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         },
         "redLight2": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         },
         "redLight3": {
-          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          }
+          },
+          "type": "string"
         }
       }
     },
     {
-      "id": "display",
       "description": "displays messages",
+      "id": "display",
       "input": {},
       "output": {
         "hint": {
-          "type": "string",
           "instructions": {
             "hint": "string"
-          }
+          },
+          "type": "string"
         }
       }
     },
     {
-      "id": "door",
       "description": "device that controls a door magnet through a relay",
+      "id": "door",
       "input": {},
       "output": {
         "door": {
-          "type": "string",
           "instructions": {
             "open": "boolean"
-          }
+          },
+          "type": "string"
         }
       }
     },
     {
-      "id": "keypad",
       "description": "Keypad with input 4 numbers",
+      "id": "keypad",
       "input": {
         "code": "numeric"
       },
       "output": {}
     }
   ],
-  "timers": [
-    {
-      "id": "timer1",
-      "duration": "10s"
-    },
-    {
-      "id": "timer2",
-      "duration": "5s"
-    },
-    {
-      "id": "timer3",
-      "duration": "1m"
-    },
-    {
-      "id": "timer4",
-      "duration": "1h"
-    },
-    {
-      "id": "timer5",
-      "duration": "20s"
-    },
-    {
-      "id": "timer6",
-      "duration": "5s"
-    }
-  ],
-  "puzzles": [
-    {
-      "name": "puzzel rood",
-      "rules": [
-        {
-          "id": "rood",
-          "description": "Wanneer de rode switch op true staat en de slider 100, dan sturen we een hint met 'puzzle rood opgelost'",
-          "limit": 1,
-          "conditions": {
-            "operator": "AND",
-            "list": [
-              {
-                "type": "device",
-                "type_id": "controlBoard",
-                "constraints": {
-                  "operator": "AND",
-                  "list": [
-                    {
-                      "component_id": "redSwitch",
-                      "comparison": "eq",
-                      "value": true
-                    },
-                    {
-                      "component_id": "slider1",
-                      "comparison": "eq",
-                      "value": 100
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "rule",
-                "type_id": "start",
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                }
-              }
-            ]
-          },
-          "actions": [
-            {
-              "type": "device",
-              "type_id": "controlBoard",
-              "message": [
-                {
-                  "component_id": "redLight1",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight1",
-                  "instruction": "turnOnOff",
-                  "value": true
-                }
-              ]
-            },
-            {
-              "type": "device",
-              "type_id": "display",
-              "message": [
-                {
-                  "component_id": "hint",
-                  "instruction": "hint",
-                  "value": "puzzle rood opgelost!"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "hints": [
-        "Zet de schuiven nauwkeurig"
-      ]
-    },
-    {
-      "name": "puzzel oranje",
-      "rules": [
-        {
-          "id": "oranje",
-          "description": "Wanneer de rode oranje op true staat en de slider tussen 50 en 80, dan sturen we een hint met 'puzzle oranje opgelost'",
-          "limit": 1,
-          "conditions": {
-            "operator": "AND",
-            "list": [
-              {
-                "type": "device",
-                "type_id": "controlBoard",
-                "constraints": {
-                  "operator": "AND",
-                  "list": [
-                    {
-                      "component_id": "orangeSwitch",
-                      "comparison": "eq",
-                      "value": true
-                    },
-                    {
-                      "component_id": "slider2",
-                      "comparison": "lte",
-                      "value": 80
-                    },
-                    {
-                      "component_id": "slider2",
-                      "comparison": "gte",
-                      "value": 50
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "rule",
-                "type_id": "start",
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                }
-              }
-            ]
-          },
-          "actions": [
-            {
-              "type": "device",
-              "type_id": "controlBoard",
-              "message": [
-                {
-                  "component_id": "redLight2",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight2",
-                  "instruction": "turnOnOff",
-                  "value": true
-                }
-              ]
-            },
-            {
-              "type": "device",
-              "type_id": "display",
-              "message": [
-                {
-                  "component_id": "hint",
-                  "instruction": "hint",
-                  "value": "puzzle oranje opgelost!"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "hints": [
-        "Zet de schuiven nauwkeurig",
-        "Probeer het nog eens",
-        "dat kan sneller"
-      ]
-    },
-    {
-      "name": "puzzel groen",
-      "rules": [
-        {
-          "id": "groen",
-          "description": "Wanneer de groen switch op true staat en de slider 100, en rule rood is al opgelost, dan sturen we een hint met 'puzzle groen opgelost'",
-          "limit": 1,
-          "conditions": {
-            "operator": "AND",
-            "list": [
-              {
-                "type": "device",
-                "type_id": "controlBoard",
-                "constraints": {
-                  "operator": "AND",
-                  "list": [
-                    {
-                      "component_id": "greenSwitch",
-                      "comparison": "eq",
-                      "value": true
-                    },
-                    {
-                      "component_id": "slider3",
-                      "comparison": "eq",
-                      "value": 100
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "rule",
-                "type_id": "rood",
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                }
-              },
-              {
-                "type": "rule",
-                "type_id": "start",
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                }
-              }
-            ]
-          },
-          "actions": [
-            {
-              "type": "device",
-              "type_id": "controlBoard",
-              "message": [
-                {
-                  "component_id": "redLight3",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight3",
-                  "instruction": "turnOnOff",
-                  "value": true
-                }
-              ]
-            },
-            {
-              "type": "device",
-              "type_id": "display",
-              "message": [
-                {
-                  "component_id": "hint",
-                  "instruction": "hint",
-                  "value": "puzzle groen opgelost!"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "hints": [
-        "Zet de schuiven nauwkeurig",
-        "Dit is dus echt best wel een superlange hint die je helemaal moet kunnen lezen"
-      ]
-    }
-  ],
+  "general": {
+    "duration": "30m",
+    "host": "192.168.178.82",
+    "name": "Escape X",
+    "port": 1883
+  },
   "general_events": [
     {
       "name": "Start knop",
       "rules": [
         {
-          "id": "start",
-          "description": "Als het spel start, moeten alle rode leds aan gaan en de groene uit",
-          "limit": 1,
-          "conditions": {
-            "operator": "OR",
-            "list": [
-              {
-                "type": "device",
-                "type_id": "front-end",
-                "constraints": {
-                  "component_id": "start",
-                  "comparison": "gte",
-                  "value": 1
-                }
-              }
-            ]
-          },
           "actions": [
             {
-              "type": "device",
-              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -426,27 +150,46 @@
                   "instruction": "turnOnOff",
                   "value": false
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "controlBoard"
             },
             {
-              "type": "timer",
-              "type_id": "timer2",
               "message": [
                 {
                   "instruction": "start"
                 }
-              ]
+              ],
+              "type": "timer",
+              "type_id": "timer2"
             },
             {
-              "type": "timer",
-              "type_id": "general",
               "message": [
                 {
                   "instruction": "start"
                 }
-              ]
+              ],
+              "type": "timer",
+              "type_id": "general"
             }
-          ]
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "comparison": "gte",
+                  "component_id": "start",
+                  "value": 1
+                },
+                "type": "device",
+                "type_id": "front-end"
+              }
+            ],
+            "operator": "OR"
+          },
+          "description": "Als het spel start, moeten alle rode leds aan gaan en de groene uit",
+          "id": "start",
+          "limit": 1
         }
       ]
     },
@@ -454,30 +197,30 @@
       "name": "late hint",
       "rules": [
         {
-          "id": "hint",
-          "description": "5 seconde na de start wordt er een hint verstuurd",
-          "limit": 1,
-          "conditions": {
-            "type": "timer",
-            "type_id": "timer2",
-            "constraints": {
-              "comparison": "eq",
-              "value": true
-            }
-          },
           "actions": [
             {
-              "type": "device",
-              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "je bent al 5 seconde bezig, misschien moet je naar het blaadje kijken :)"
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "display"
             }
-          ]
+          ],
+          "conditions": {
+            "constraints": {
+              "comparison": "eq",
+              "value": true
+            },
+            "type": "timer",
+            "type_id": "timer2"
+          },
+          "description": "5 seconde na de start wordt er een hint verstuurd",
+          "id": "hint",
+          "limit": 1
         }
       ]
     },
@@ -485,32 +228,19 @@
       "name": "Stop Time up",
       "rules": [
         {
-          "id": "time up",
-          "description": "Na de duration van het spel faalt de groep",
-          "limit": 1,
-          "conditions": {
-            "type": "timer",
-            "type_id": "general",
-            "constraints": {
-              "comparison": "eq",
-              "value": true
-            }
-          },
           "actions": [
             {
-              "type": "device",
-              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "Je tijd is voorbij!"
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "display"
             },
             {
-              "type": "device",
-              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -542,9 +272,22 @@
                   "instruction": "turnOnOff",
                   "value": true
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "controlBoard"
             }
-          ]
+          ],
+          "conditions": {
+            "constraints": {
+              "comparison": "eq",
+              "value": true
+            },
+            "type": "timer",
+            "type_id": "general"
+          },
+          "description": "Na de duration van het spel faalt de groep",
+          "id": "time up",
+          "limit": 1
         }
       ]
     },
@@ -552,53 +295,19 @@
       "name": "Stop Done",
       "rules": [
         {
-          "id": "Puzzles done",
-          "description": "Puzzles zijn opgelost dus time stop",
-          "limit": 1,
-          "conditions": {
-            "operator": "AND",
-            "list": [
-              {
-                "type": "rule",
-                "type_id": "rood",
-                "constraints": {
-                  "comparison": "eq",
-                  "value": 1
-                }
-              },
-              {
-                "type": "rule",
-                "type_id": "groen",
-                "constraints": {
-                  "comparison": "eq",
-                  "value": 1
-                }
-              },
-              {
-                "type": "rule",
-                "type_id": "oranje",
-                "constraints": {
-                  "comparison": "eq",
-                  "value": 1
-                }
-              }
-            ]
-          },
           "actions": [
             {
-              "type": "device",
-              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "Puzzle opgelost!"
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "display"
             },
             {
-              "type": "device",
-              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -630,18 +339,52 @@
                   "instruction": "turnOnOff",
                   "value": true
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "controlBoard"
             },
             {
-              "type": "timer",
-              "type_id": "general",
               "message": [
                 {
                   "instruction": "pause"
                 }
-              ]
+              ],
+              "type": "timer",
+              "type_id": "general"
             }
-          ]
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "comparison": "eq",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "rood"
+              },
+              {
+                "constraints": {
+                  "comparison": "eq",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "groen"
+              },
+              {
+                "constraints": {
+                  "comparison": "eq",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "oranje"
+              }
+            ],
+            "operator": "AND"
+          },
+          "description": "Puzzles zijn opgelost dus time stop",
+          "id": "Puzzles done",
+          "limit": 1
         }
       ]
     },
@@ -649,36 +392,17 @@
       "name": "Stop knop",
       "rules": [
         {
-          "id": "stop",
-          "description": "Als het spel stopt, moeten alle lichten uitgaan",
-          "limit": 1,
-          "conditions": {
-            "operator": "OR",
-            "list": [
-              {
-                "type": "device",
-                "type_id": "front-end",
-                "constraints": {
-                  "component_id": "stop",
-                  "comparison": "eq",
-                  "value": 1
-                }
-              }
-            ]
-          },
           "actions": [
             {
-              "type": "timer",
-              "type_id": "general",
               "message": [
                 {
                   "instruction": "pause"
                 }
-              ]
+              ],
+              "type": "timer",
+              "type_id": "general"
             },
             {
-              "type": "device",
-              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -710,11 +434,296 @@
                   "instruction": "turnOnOff",
                   "value": false
                 }
-              ]
+              ],
+              "type": "device",
+              "type_id": "controlBoard"
             }
-          ]
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "comparison": "eq",
+                  "component_id": "stop",
+                  "value": 1
+                },
+                "type": "device",
+                "type_id": "front-end"
+              }
+            ],
+            "operator": "OR"
+          },
+          "description": "Als het spel stopt, moeten alle lichten uitgaan",
+          "id": "stop",
+          "limit": 1
         }
       ]
+    }
+  ],
+  "puzzles": [
+    {
+      "hints": [
+        "Zet de schuiven nauwkeurig"
+      ],
+      "name": "puzzel rood",
+      "rules": [
+        {
+          "actions": [
+            {
+              "message": [
+                {
+                  "component_id": "redLight1",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight1",
+                  "instruction": "turnOnOff",
+                  "value": true
+                }
+              ],
+              "type": "device",
+              "type_id": "controlBoard"
+            },
+            {
+              "message": [
+                {
+                  "component_id": "hint",
+                  "instruction": "hint",
+                  "value": "puzzle rood opgelost!"
+                }
+              ],
+              "type": "device",
+              "type_id": "display"
+            }
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "list": [
+                    {
+                      "comparison": "eq",
+                      "component_id": "redSwitch",
+                      "value": true
+                    },
+                    {
+                      "comparison": "eq",
+                      "component_id": "slider1",
+                      "value": 100
+                    }
+                  ],
+                  "operator": "AND"
+                },
+                "type": "device",
+                "type_id": "controlBoard"
+              },
+              {
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "start"
+              }
+            ],
+            "operator": "AND"
+          },
+          "description": "Wanneer de rode switch op true staat en de slider 100, dan sturen we een hint met 'puzzle rood opgelost'",
+          "id": "rood",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "hints": [
+        "Zet de schuiven nauwkeurig",
+        "Probeer het nog eens",
+        "dat kan sneller"
+      ],
+      "name": "puzzel oranje",
+      "rules": [
+        {
+          "actions": [
+            {
+              "message": [
+                {
+                  "component_id": "redLight2",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight2",
+                  "instruction": "turnOnOff",
+                  "value": true
+                }
+              ],
+              "type": "device",
+              "type_id": "controlBoard"
+            },
+            {
+              "message": [
+                {
+                  "component_id": "hint",
+                  "instruction": "hint",
+                  "value": "puzzle oranje opgelost!"
+                }
+              ],
+              "type": "device",
+              "type_id": "display"
+            }
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "list": [
+                    {
+                      "comparison": "eq",
+                      "component_id": "orangeSwitch",
+                      "value": true
+                    },
+                    {
+                      "comparison": "lte",
+                      "component_id": "slider2",
+                      "value": 80
+                    },
+                    {
+                      "comparison": "gte",
+                      "component_id": "slider2",
+                      "value": 50
+                    }
+                  ],
+                  "operator": "AND"
+                },
+                "type": "device",
+                "type_id": "controlBoard"
+              },
+              {
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "start"
+              }
+            ],
+            "operator": "AND"
+          },
+          "description": "Wanneer de rode oranje op true staat en de slider tussen 50 en 80, dan sturen we een hint met 'puzzle oranje opgelost'",
+          "id": "oranje",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "hints": [
+        "Zet de schuiven nauwkeurig",
+        "Dit is dus echt best wel een superlange hint die je helemaal moet kunnen lezen"
+      ],
+      "name": "puzzel groen",
+      "rules": [
+        {
+          "actions": [
+            {
+              "message": [
+                {
+                  "component_id": "redLight3",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight3",
+                  "instruction": "turnOnOff",
+                  "value": true
+                }
+              ],
+              "type": "device",
+              "type_id": "controlBoard"
+            },
+            {
+              "message": [
+                {
+                  "component_id": "hint",
+                  "instruction": "hint",
+                  "value": "puzzle groen opgelost!"
+                }
+              ],
+              "type": "device",
+              "type_id": "display"
+            }
+          ],
+          "conditions": {
+            "list": [
+              {
+                "constraints": {
+                  "list": [
+                    {
+                      "comparison": "eq",
+                      "component_id": "greenSwitch",
+                      "value": true
+                    },
+                    {
+                      "comparison": "eq",
+                      "component_id": "slider3",
+                      "value": 100
+                    }
+                  ],
+                  "operator": "AND"
+                },
+                "type": "device",
+                "type_id": "controlBoard"
+              },
+              {
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "rood"
+              },
+              {
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                },
+                "type": "rule",
+                "type_id": "start"
+              }
+            ],
+            "operator": "AND"
+          },
+          "description": "Wanneer de groen switch op true staat en de slider 100, en rule rood is al opgelost, dan sturen we een hint met 'puzzle groen opgelost'",
+          "id": "groen",
+          "limit": 1
+        }
+      ]
+    }
+  ],
+  "timers": [
+    {
+      "duration": "10s",
+      "id": "timer1"
+    },
+    {
+      "duration": "5s",
+      "id": "timer2"
+    },
+    {
+      "duration": "1m",
+      "id": "timer3"
+    },
+    {
+      "duration": "1h",
+      "id": "timer4"
+    },
+    {
+      "duration": "20s",
+      "id": "timer5"
+    },
+    {
+      "duration": "5s",
+      "id": "timer6"
     }
   ]
 }

--- a/back-end/resources/room_config.json
+++ b/back-end/resources/room_config.json
@@ -1,124 +1,400 @@
 {
-  "cameras": [
-    {
-      "link": "https://raccoon.games",
-      "name": "camera1"
-    },
-    {
-      "link": "https://debrouwerij.io",
-      "name": "camera2"
-    },
-    {
-      "link": "https://www.youtube.com/embed/tgbNymZ7vqY",
-      "name": "muppets"
-    }
+  "general": {
+    "name": "Escape X",
+    "duration": "30m",
+    "host": "192.168.178.82",
+    "port": 1883
+  },
+   "cameras": [
+     {"name": "camera1", "link": "https://raccoon.games"},
+     {"name": "camera2", "link": "https://debrouwerij.io"},
+     {"name": "muppets", "link": "https://www.youtube.com/embed/tgbNymZ7vqY"}
   ],
   "devices": [
     {
-      "description": "Control board with three switches, three slides with lights and one main switch.",
       "id": "controlBoard",
+      "description": "Control board with three switches, three slides with lights and one main switch.",
       "input": {
-        "greenSwitch": "boolean",
-        "mainSwitch": "boolean",
-        "orangeSwitch": "boolean",
         "redSwitch": "boolean",
+        "orangeSwitch": "boolean",
+        "greenSwitch": "boolean",
         "slider1": "numeric",
         "slider2": "numeric",
-        "slider3": "numeric"
+        "slider3": "numeric",
+        "mainSwitch": "boolean"
       },
       "output": {
         "greenLight1": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         },
         "greenLight2": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         },
         "greenLight3": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         },
         "redLight1": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         },
         "redLight2": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         },
         "redLight3": {
+          "type": "string",
           "instructions": {
             "blink": "array",
             "turnOnOff": "boolean"
-          },
-          "type": "string"
+          }
         }
       }
     },
     {
-      "description": "displays messages",
       "id": "display",
+      "description": "displays messages",
       "input": {},
       "output": {
         "hint": {
+          "type": "string",
           "instructions": {
             "hint": "string"
-          },
-          "type": "string"
+          }
         }
       }
     },
     {
-      "description": "device that controls a door magnet through a relay",
       "id": "door",
+      "description": "device that controls a door magnet through a relay",
       "input": {},
       "output": {
         "door": {
+          "type": "string",
           "instructions": {
             "open": "boolean"
-          },
-          "type": "string"
+          }
         }
       }
     },
     {
-      "description": "Keypad with input 4 numbers",
       "id": "keypad",
+      "description": "Keypad with input 4 numbers",
       "input": {
         "code": "numeric"
       },
       "output": {}
     }
   ],
-  "general": {
-    "duration": "30m",
-    "host": "192.168.178.82",
-    "name": "Escape X",
-    "port": 1883
-  },
+  "timers": [
+    {
+      "id": "timer1",
+      "duration": "10s"
+    },
+    {
+      "id": "timer2",
+      "duration": "5s"
+    },
+    {
+      "id": "timer3",
+      "duration": "1m"
+    },
+    {
+      "id": "timer4",
+      "duration": "1h"
+    },
+    {
+      "id": "timer5",
+      "duration": "20s"
+    },
+    {
+      "id": "timer6",
+      "duration": "5s"
+    }
+  ],
+  "puzzles": [
+    {
+      "name": "puzzel rood",
+      "rules": [
+        {
+          "id": "rood",
+          "description": "Wanneer de rode switch op true staat en de slider 100, dan sturen we een hint met 'puzzle rood opgelost'",
+          "limit": 1,
+          "conditions": {
+            "operator": "AND",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "controlBoard",
+                "constraints": {
+                  "operator": "AND",
+                  "list": [
+                    {
+                      "component_id": "redSwitch",
+                      "comparison": "eq",
+                      "value": true
+                    },
+                    {
+                      "component_id": "slider1",
+                      "comparison": "eq",
+                      "value": 100
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "start",
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                }
+              }
+            ]
+          },
+          "actions": [
+            {
+              "type": "device",
+              "type_id": "controlBoard",
+              "message": [
+                {
+                  "component_id": "redLight1",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight1",
+                  "instruction": "turnOnOff",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "type": "device",
+              "type_id": "display",
+              "message": [
+                {
+                  "component_id": "hint",
+                  "instruction": "hint",
+                  "value": "puzzle rood opgelost!"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "hints": [
+        "Zet de schuiven nauwkeurig"
+      ]
+    },
+    {
+      "name": "puzzel oranje",
+      "rules": [
+        {
+          "id": "oranje",
+          "description": "Wanneer de rode oranje op true staat en de slider tussen 50 en 80, dan sturen we een hint met 'puzzle oranje opgelost'",
+          "limit": 1,
+          "conditions": {
+            "operator": "AND",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "controlBoard",
+                "constraints": {
+                  "operator": "AND",
+                  "list": [
+                    {
+                      "component_id": "orangeSwitch",
+                      "comparison": "eq",
+                      "value": true
+                    },
+                    {
+                      "component_id": "slider2",
+                      "comparison": "lte",
+                      "value": 80
+                    },
+                    {
+                      "component_id": "slider2",
+                      "comparison": "gte",
+                      "value": 50
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "start",
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                }
+              }
+            ]
+          },
+          "actions": [
+            {
+              "type": "device",
+              "type_id": "controlBoard",
+              "message": [
+                {
+                  "component_id": "redLight2",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight2",
+                  "instruction": "turnOnOff",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "type": "device",
+              "type_id": "display",
+              "message": [
+                {
+                  "component_id": "hint",
+                  "instruction": "hint",
+                  "value": "puzzle oranje opgelost!"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "hints": [
+        "Zet de schuiven nauwkeurig",
+        "Probeer het nog eens",
+        "dat kan sneller"
+      ]
+    },
+    {
+      "name": "puzzel groen",
+      "rules": [
+        {
+          "id": "groen",
+          "description": "Wanneer de groen switch op true staat en de slider 100, en rule rood is al opgelost, dan sturen we een hint met 'puzzle groen opgelost'",
+          "limit": 1,
+          "conditions": {
+            "operator": "AND",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "controlBoard",
+                "constraints": {
+                  "operator": "AND",
+                  "list": [
+                    {
+                      "component_id": "greenSwitch",
+                      "comparison": "eq",
+                      "value": true
+                    },
+                    {
+                      "component_id": "slider3",
+                      "comparison": "eq",
+                      "value": 100
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "rood",
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "start",
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 1
+                }
+              }
+            ]
+          },
+          "actions": [
+            {
+              "type": "device",
+              "type_id": "controlBoard",
+              "message": [
+                {
+                  "component_id": "redLight3",
+                  "instruction": "turnOnOff",
+                  "value": false
+                },
+                {
+                  "component_id": "greenLight3",
+                  "instruction": "turnOnOff",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "type": "device",
+              "type_id": "display",
+              "message": [
+                {
+                  "component_id": "hint",
+                  "instruction": "hint",
+                  "value": "puzzle groen opgelost!"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "hints": [
+        "Zet de schuiven nauwkeurig",
+        "Dit is dus echt best wel een superlange hint die je helemaal moet kunnen lezen"
+      ]
+    }
+  ],
   "general_events": [
     {
       "name": "Start knop",
       "rules": [
         {
+          "id": "start",
+          "description": "Als het spel start, moeten alle rode leds aan gaan en de groene uit",
+          "limit": 1,
+          "conditions": {
+            "operator": "OR",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "front-end",
+                "constraints": {
+                  "component_id": "start",
+                  "comparison": "gte",
+                  "value": 1
+                }
+              }
+            ]
+          },
           "actions": [
             {
+              "type": "device",
+              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -150,46 +426,27 @@
                   "instruction": "turnOnOff",
                   "value": false
                 }
-              ],
-              "type": "device",
-              "type_id": "controlBoard"
+              ]
             },
             {
+              "type": "timer",
+              "type_id": "timer2",
               "message": [
                 {
                   "instruction": "start"
                 }
-              ],
-              "type": "timer",
-              "type_id": "timer2"
+              ]
             },
             {
+              "type": "timer",
+              "type_id": "general",
               "message": [
                 {
                   "instruction": "start"
                 }
-              ],
-              "type": "timer",
-              "type_id": "general"
+              ]
             }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "comparison": "gte",
-                  "component_id": "start",
-                  "value": 1
-                },
-                "type": "device",
-                "type_id": "front-end"
-              }
-            ],
-            "operator": "OR"
-          },
-          "description": "Als het spel start, moeten alle rode leds aan gaan en de groene uit",
-          "id": "start",
-          "limit": 1
+          ]
         }
       ]
     },
@@ -197,30 +454,30 @@
       "name": "late hint",
       "rules": [
         {
+          "id": "hint",
+          "description": "5 seconde na de start wordt er een hint verstuurd",
+          "limit": 1,
+          "conditions": {
+            "type": "timer",
+            "type_id": "timer2",
+            "constraints": {
+              "comparison": "eq",
+              "value": true
+            }
+          },
           "actions": [
             {
+              "type": "device",
+              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "je bent al 5 seconde bezig, misschien moet je naar het blaadje kijken :)"
                 }
-              ],
-              "type": "device",
-              "type_id": "display"
+              ]
             }
-          ],
-          "conditions": {
-            "constraints": {
-              "comparison": "eq",
-              "value": true
-            },
-            "type": "timer",
-            "type_id": "timer2"
-          },
-          "description": "5 seconde na de start wordt er een hint verstuurd",
-          "id": "hint",
-          "limit": 1
+          ]
         }
       ]
     },
@@ -228,19 +485,32 @@
       "name": "Stop Time up",
       "rules": [
         {
+          "id": "time up",
+          "description": "Na de duration van het spel faalt de groep",
+          "limit": 1,
+          "conditions": {
+            "type": "timer",
+            "type_id": "general",
+            "constraints": {
+              "comparison": "eq",
+              "value": true
+            }
+          },
           "actions": [
             {
+              "type": "device",
+              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "Je tijd is voorbij!"
                 }
-              ],
-              "type": "device",
-              "type_id": "display"
+              ]
             },
             {
+              "type": "device",
+              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -272,22 +542,9 @@
                   "instruction": "turnOnOff",
                   "value": true
                 }
-              ],
-              "type": "device",
-              "type_id": "controlBoard"
+              ]
             }
-          ],
-          "conditions": {
-            "constraints": {
-              "comparison": "eq",
-              "value": true
-            },
-            "type": "timer",
-            "type_id": "general"
-          },
-          "description": "Na de duration van het spel faalt de groep",
-          "id": "time up",
-          "limit": 1
+          ]
         }
       ]
     },
@@ -295,19 +552,53 @@
       "name": "Stop Done",
       "rules": [
         {
+          "id": "Puzzles done",
+          "description": "Puzzles zijn opgelost dus time stop",
+          "limit": 1,
+          "conditions": {
+            "operator": "AND",
+            "list": [
+              {
+                "type": "rule",
+                "type_id": "rood",
+                "constraints": {
+                  "comparison": "eq",
+                  "value": 1
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "groen",
+                "constraints": {
+                  "comparison": "eq",
+                  "value": 1
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "oranje",
+                "constraints": {
+                  "comparison": "eq",
+                  "value": 1
+                }
+              }
+            ]
+          },
           "actions": [
             {
+              "type": "device",
+              "type_id": "display",
               "message": [
                 {
                   "component_id": "hint",
                   "instruction": "hint",
                   "value": "Puzzle opgelost!"
                 }
-              ],
-              "type": "device",
-              "type_id": "display"
+              ]
             },
             {
+              "type": "device",
+              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -339,52 +630,18 @@
                   "instruction": "turnOnOff",
                   "value": true
                 }
-              ],
-              "type": "device",
-              "type_id": "controlBoard"
+              ]
             },
             {
+              "type": "timer",
+              "type_id": "general",
               "message": [
                 {
                   "instruction": "pause"
                 }
-              ],
-              "type": "timer",
-              "type_id": "general"
+              ]
             }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "comparison": "eq",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "rood"
-              },
-              {
-                "constraints": {
-                  "comparison": "eq",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "groen"
-              },
-              {
-                "constraints": {
-                  "comparison": "eq",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "oranje"
-              }
-            ],
-            "operator": "AND"
-          },
-          "description": "Puzzles zijn opgelost dus time stop",
-          "id": "Puzzles done",
-          "limit": 1
+          ]
         }
       ]
     },
@@ -392,17 +649,36 @@
       "name": "Stop knop",
       "rules": [
         {
+          "id": "stop",
+          "description": "Als het spel stopt, moeten alle lichten uitgaan",
+          "limit": 1,
+          "conditions": {
+            "operator": "OR",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "front-end",
+                "constraints": {
+                  "component_id": "stop",
+                  "comparison": "eq",
+                  "value": 1
+                }
+              }
+            ]
+          },
           "actions": [
             {
+              "type": "timer",
+              "type_id": "general",
               "message": [
                 {
                   "instruction": "pause"
                 }
-              ],
-              "type": "timer",
-              "type_id": "general"
+              ]
             },
             {
+              "type": "device",
+              "type_id": "controlBoard",
               "message": [
                 {
                   "component_id": "redLight1",
@@ -434,296 +710,11 @@
                   "instruction": "turnOnOff",
                   "value": false
                 }
-              ],
-              "type": "device",
-              "type_id": "controlBoard"
+              ]
             }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "comparison": "eq",
-                  "component_id": "stop",
-                  "value": 1
-                },
-                "type": "device",
-                "type_id": "front-end"
-              }
-            ],
-            "operator": "OR"
-          },
-          "description": "Als het spel stopt, moeten alle lichten uitgaan",
-          "id": "stop",
-          "limit": 1
+          ]
         }
       ]
-    }
-  ],
-  "puzzles": [
-    {
-      "hints": [
-        "Zet de schuiven nauwkeurig"
-      ],
-      "name": "puzzel rood",
-      "rules": [
-        {
-          "actions": [
-            {
-              "message": [
-                {
-                  "component_id": "redLight1",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight1",
-                  "instruction": "turnOnOff",
-                  "value": true
-                }
-              ],
-              "type": "device",
-              "type_id": "controlBoard"
-            },
-            {
-              "message": [
-                {
-                  "component_id": "hint",
-                  "instruction": "hint",
-                  "value": "puzzle rood opgelost!"
-                }
-              ],
-              "type": "device",
-              "type_id": "display"
-            }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "list": [
-                    {
-                      "comparison": "eq",
-                      "component_id": "redSwitch",
-                      "value": true
-                    },
-                    {
-                      "comparison": "eq",
-                      "component_id": "slider1",
-                      "value": 100
-                    }
-                  ],
-                  "operator": "AND"
-                },
-                "type": "device",
-                "type_id": "controlBoard"
-              },
-              {
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "start"
-              }
-            ],
-            "operator": "AND"
-          },
-          "description": "Wanneer de rode switch op true staat en de slider 100, dan sturen we een hint met 'puzzle rood opgelost'",
-          "id": "rood",
-          "limit": 1
-        }
-      ]
-    },
-    {
-      "hints": [
-        "Zet de schuiven nauwkeurig",
-        "Probeer het nog eens",
-        "dat kan sneller"
-      ],
-      "name": "puzzel oranje",
-      "rules": [
-        {
-          "actions": [
-            {
-              "message": [
-                {
-                  "component_id": "redLight2",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight2",
-                  "instruction": "turnOnOff",
-                  "value": true
-                }
-              ],
-              "type": "device",
-              "type_id": "controlBoard"
-            },
-            {
-              "message": [
-                {
-                  "component_id": "hint",
-                  "instruction": "hint",
-                  "value": "puzzle oranje opgelost!"
-                }
-              ],
-              "type": "device",
-              "type_id": "display"
-            }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "list": [
-                    {
-                      "comparison": "eq",
-                      "component_id": "orangeSwitch",
-                      "value": true
-                    },
-                    {
-                      "comparison": "lte",
-                      "component_id": "slider2",
-                      "value": 80
-                    },
-                    {
-                      "comparison": "gte",
-                      "component_id": "slider2",
-                      "value": 50
-                    }
-                  ],
-                  "operator": "AND"
-                },
-                "type": "device",
-                "type_id": "controlBoard"
-              },
-              {
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "start"
-              }
-            ],
-            "operator": "AND"
-          },
-          "description": "Wanneer de rode oranje op true staat en de slider tussen 50 en 80, dan sturen we een hint met 'puzzle oranje opgelost'",
-          "id": "oranje",
-          "limit": 1
-        }
-      ]
-    },
-    {
-      "hints": [
-        "Zet de schuiven nauwkeurig",
-        "Dit is dus echt best wel een superlange hint die je helemaal moet kunnen lezen"
-      ],
-      "name": "puzzel groen",
-      "rules": [
-        {
-          "actions": [
-            {
-              "message": [
-                {
-                  "component_id": "redLight3",
-                  "instruction": "turnOnOff",
-                  "value": false
-                },
-                {
-                  "component_id": "greenLight3",
-                  "instruction": "turnOnOff",
-                  "value": true
-                }
-              ],
-              "type": "device",
-              "type_id": "controlBoard"
-            },
-            {
-              "message": [
-                {
-                  "component_id": "hint",
-                  "instruction": "hint",
-                  "value": "puzzle groen opgelost!"
-                }
-              ],
-              "type": "device",
-              "type_id": "display"
-            }
-          ],
-          "conditions": {
-            "list": [
-              {
-                "constraints": {
-                  "list": [
-                    {
-                      "comparison": "eq",
-                      "component_id": "greenSwitch",
-                      "value": true
-                    },
-                    {
-                      "comparison": "eq",
-                      "component_id": "slider3",
-                      "value": 100
-                    }
-                  ],
-                  "operator": "AND"
-                },
-                "type": "device",
-                "type_id": "controlBoard"
-              },
-              {
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "rood"
-              },
-              {
-                "constraints": {
-                  "comparison": "gte",
-                  "value": 1
-                },
-                "type": "rule",
-                "type_id": "start"
-              }
-            ],
-            "operator": "AND"
-          },
-          "description": "Wanneer de groen switch op true staat en de slider 100, en rule rood is al opgelost, dan sturen we een hint met 'puzzle groen opgelost'",
-          "id": "groen",
-          "limit": 1
-        }
-      ]
-    }
-  ],
-  "timers": [
-    {
-      "duration": "10s",
-      "id": "timer1"
-    },
-    {
-      "duration": "5s",
-      "id": "timer2"
-    },
-    {
-      "duration": "1m",
-      "id": "timer3"
-    },
-    {
-      "duration": "1h",
-      "id": "timer4"
-    },
-    {
-      "duration": "20s",
-      "id": "timer5"
-    },
-    {
-      "duration": "5s",
-      "id": "timer6"
     }
   ]
 }

--- a/back-end/resources/testing/testComponentConstraintNotPresent.json
+++ b/back-end/resources/testing/testComponentConstraintNotPresent.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "192.0.0.84",
     "port": 1883
   },

--- a/back-end/resources/testing/testDeviceConstraintNotPresent.json
+++ b/back-end/resources/testing/testDeviceConstraintNotPresent.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/testDurationErrorWrongFormat.json
+++ b/back-end/resources/testing/testDurationErrorWrongFormat.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "30m",
+    "duration": "30",
     "host": "192.0.0.84",
     "port": 1883
   },
@@ -29,19 +29,6 @@
     {
       "id": "timer6",
       "duration": "5s"
-    }
-  ],
-  "devices": [
-    {
-      "id": "telephone",
-      "description": "The telephone can ring and display a message. It will also record the numbers turned, and send these as sequence",
-      "input": {
-        "turningWheel": 0
-      },
-      "output": {
-        "audio": "audio1",
-        "ringTone": "string"
-      }
     }
   ]
 }

--- a/back-end/resources/testing/testDurationTimerError.json
+++ b/back-end/resources/testing/testDurationTimerError.json
@@ -8,7 +8,7 @@
   "timers": [
     {
       "id": "timer1",
-      "duration": "10s"
+      "duration": 10
     },
     {
       "id": "timer2",
@@ -29,19 +29,6 @@
     {
       "id": "timer6",
       "duration": "5s"
-    }
-  ],
-  "devices": [
-    {
-      "id": "telephone",
-      "description": "The telephone can ring and display a message. It will also record the numbers turned, and send these as sequence",
-      "input": {
-        "turningWheel": 0
-      },
-      "output": {
-        "audio": "audio1",
-        "ringTone": "string"
-      }
     }
   ]
 }

--- a/back-end/resources/testing/testDurationTimerErrorWrongFormat.json
+++ b/back-end/resources/testing/testDurationTimerErrorWrongFormat.json
@@ -8,7 +8,7 @@
   "timers": [
     {
       "id": "timer1",
-      "duration": "10s"
+      "duration": "10x"
     },
     {
       "id": "timer2",
@@ -29,19 +29,6 @@
     {
       "id": "timer6",
       "duration": "5s"
-    }
-  ],
-  "devices": [
-    {
-      "id": "telephone",
-      "description": "The telephone can ring and display a message. It will also record the numbers turned, and send these as sequence",
-      "input": {
-        "turningWheel": 0
-      },
-      "output": {
-        "audio": "audio1",
-        "ringTone": "string"
-      }
     }
   ]
 }

--- a/back-end/resources/testing/testIncorrectConditionOperator.json
+++ b/back-end/resources/testing/testIncorrectConditionOperator.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/testIncorrectConstraintOperator.json
+++ b/back-end/resources/testing/testIncorrectConstraintOperator.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/testIncorrectTypeCondition.json
+++ b/back-end/resources/testing/testIncorrectTypeCondition.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/testWrongComponentIDType.json
+++ b/back-end/resources/testing/testWrongComponentIDType.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/testWrongConditionStructure.json
+++ b/back-end/resources/testing/testWrongConditionStructure.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/testWrongConstraintStructure.json
+++ b/back-end/resources/testing/testWrongConstraintStructure.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/test_config_errors.json
+++ b/back-end/resources/testing/test_config_errors.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": 30,
+    "duration": "30",
     "host": "localhost",
     "port": 1883
   },
@@ -110,7 +110,7 @@
   "timers": [
     {
       "id": "timer1",
-      "duration": "10s"
+      "duration": "10x"
     },
     {
       "id": "timer2",
@@ -140,10 +140,10 @@
         {
           "id": "correctSequence",
           "description": "De juiste volgorde van cijfers moet gedraaid worden.",
-          "limit": 1,
+          "limit": 7,
           "conditions": {
             "type": "device",
-            "type_id": "telephone",
+            "type_id": "testDevice",
             "constraints": {
               "comparison": "eq",
               "component_id": "turningWheel",

--- a/back-end/resources/testing/test_config_errors.json
+++ b/back-end/resources/testing/test_config_errors.json
@@ -1,0 +1,366 @@
+{
+  "general": {
+    "name": "Escape X",
+    "duration": 30,
+    "host": "localhost",
+    "port": 1883
+  },
+  "cameras": [
+    {"name": "camera1", "link": "https://raccoon.games"},
+    {"name": "camera2", "link": "https://debrouwerij.io"}
+  ],
+  "devices": [
+    {
+      "id": "controlBoard",
+      "description": "Control board with three switches, three slides with lights and one main switch.",
+      "input": {
+        "redSwitch": "boolean",
+        "orangeSwitch": "boolean",
+        "greenSwitch": "boolean",
+        "slider1": "numeric",
+        "slider2": "numeric",
+        "slider3": "numeric",
+        "mainSwitch": "boolean"
+      },
+      "output": {
+        "greenLight1": {
+          "type": "string",
+          "instructions": {
+            "interval": "numeric",
+            "delay": "numeric",
+            "state": "string"
+          }
+        },
+        "greenLight2": {
+          "type": "string",
+          "instructions": {
+            "interval": "numeric",
+            "delay": "numeric",
+            "state": "string"
+          }
+        },
+        "greenLight3": {
+          "type": "string",
+          "instructions": {
+            "interval": "numeric",
+            "delay": "numeric",
+            "state": "string"
+          }
+        },
+        "redLight1": {
+          "type": "string",
+          "instructions": {
+            "interval": "numeric",
+            "delay": "numeric",
+            "state": "string"
+          }
+        },
+        "redLight2": {
+          "type": "string",
+          "instructions": {
+            "interval": "numeric",
+            "delay": "numeric",
+            "state": "string"
+          }
+        },
+        "redLight3": {
+          "type": "string",
+          "instructions": {
+            "interval": "numeric",
+            "delay": "numeric",
+            "state": "string"
+          }
+        }
+      }
+    },
+    {
+      "id": "telephone",
+      "description": "The telephone can ring and display a message. It will also record the numbers turned, and send these as sequence",
+      "input": {
+        "turningWheel": "array"
+      },
+      "output": {
+        "audio": {
+          "type": "string",
+          "instructions": {
+            "play": "string"
+          }
+        },
+        "ringTone": {
+          "type": "string",
+          "instructions": {
+            "play": "string"
+          }
+        }
+      }
+    },
+    {
+      "id": "test device",
+      "description": "device that has all types of input",
+      "input": {
+        "numeric": "numeric",
+        "boolean": "boolean",
+        "string": "string",
+        "array": "array",
+        "custom": "custom"
+      },
+      "output": {}
+    }
+  ],
+  "timers": [
+    {
+      "id": "timer1",
+      "duration": "10s"
+    },
+    {
+      "id": "timer2",
+      "duration": "5s"
+    },
+    {
+      "id": "timer3",
+      "duration": "1m"
+    },
+    {
+      "id": "timer4",
+      "duration": "1h"
+    },
+    {
+      "id": "timer5",
+      "duration": "20s"
+    },
+    {
+      "id": "timer6",
+      "duration": "5s"
+    }
+  ],
+  "puzzles": [
+    {
+      "name": "Telefoon puzzels",
+      "rules": [
+        {
+          "id": "correctSequence",
+          "description": "De juiste volgorde van cijfers moet gedraaid worden.",
+          "limit": 1,
+          "conditions": {
+            "type": "device",
+            "type_id": "telephone",
+            "constraints": {
+              "comparison": "eq",
+              "component_id": "turningWheel",
+              "value": [
+                0,
+                1,
+                2,
+                7
+              ]
+            }
+          },
+          "actions": [
+            {
+              "type": "device",
+              "type_id": "controlBoard",
+              "message": [
+                {
+                  "component_id": "greenLight1",
+                  "instruction": "interval",
+                  "value": 0.5
+                },
+                {
+                  "component_id": "greenLight1",
+                  "instruction": "delay",
+                  "value": 0
+                },
+                {
+                  "component_id": "greenLight1",
+                  "instruction": "state",
+                  "value": "blink"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "hints": [
+        "De knop verzend jouw volgorde",
+        "Heb je al even gewacht?"
+      ]
+    },
+    {
+      "name": "Control puzzel",
+      "rules": [
+        {
+          "id": "controlSwitch",
+          "description": "Als de grote switch wordt geflipt, worden alle condities gecheckt (tweede schuif en groene of rode switch aan) en gaat het lichtje branden en de telefoon ringt.",
+          "limit": 1,
+          "conditions": {
+            "operator": "AND",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "controlBoard",
+                "constraints": {
+                  "operator": "OR",
+                  "list": [
+                    {
+                      "component_id": "mainSwitch",
+                      "comparison": "eq",
+                      "value": true
+                    },
+                    {
+                      "component_id": "greenSwitch",
+                      "comparison": "eq",
+                      "value": true
+                    },
+                    {
+                      "component_id": "redSwitch",
+                      "comparison": "eq",
+                      "value": true
+                    },
+                    {
+                      "component_id": "slider2",
+                      "comparison": "lt",
+                      "value": 20
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "correctSequence",
+                "constraints": {
+                  "comparison": "gte",
+                  "value": 2
+                }
+              }
+            ]
+          },
+          "actions": [
+            {
+              "type": "device",
+              "type_id": "telephone",
+              "message": [
+                {
+                  "component_id": "audio",
+                  "instruction": "play",
+                  "value": "audio1"
+                }
+              ]
+            },
+            {
+              "type": "device",
+              "type_id": "controlBoard",
+              "message": [
+                {
+                  "component_id": "greenLight1",
+                  "instruction": "state",
+                  "value": "off"
+                },
+                {
+                  "component_id": "greenLight2",
+                  "instruction": "state",
+                  "value": "on"
+                },
+                {
+                  "component_id": "greenLight3",
+                  "instruction": "state",
+                  "value": "off"
+                },
+                {
+                  "component_id": "redLight1",
+                  "instruction": "state",
+                  "value": "on"
+                },
+                {
+                  "component_id": "redLight2",
+                  "instruction": "state",
+                  "value": "off"
+                },
+                {
+                  "component_id": "redLight3",
+                  "instruction": "state",
+                  "value": "on"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "hints": [
+        "Zet de schuiven nauwkeurig"
+      ]
+    }
+  ],
+  "general_events": [
+    {
+      "name": "Start",
+      "rules": [
+        {
+          "id": "telephoneRings",
+          "description": "Als het spel start, moet de telefoon na 1 minuut ringen.",
+          "limit": 1,
+          "conditions": {
+            "operator": "OR",
+            "list": [
+              {
+                "type": "timer",
+                "type_id": "timer1",
+                "constraints": {
+                  "operator": "AND",
+                  "list": [
+                    {
+                      "comparison": "eq",
+                      "value": true
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "actions": [
+            {
+              "type": "device",
+              "type_id": "telephone",
+              "message": [
+                {
+                  "component_id": "audio",
+                  "instruction": "play",
+                  "value": "audio1"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Stop",
+      "rules": [
+        {
+          "id": "flipSwitch",
+          "description": "Als de knop omgaat, stopt het spel.",
+          "limit": 1,
+          "conditions": {
+            "type": "device",
+            "type_id": "controlBoard",
+            "constraints": {
+              "comparison": "eq",
+              "value": true,
+              "component_id": "mainSwitch"
+            }
+          },
+          "actions": [
+            {
+              "type": "timer",
+              "type_id": "timer10",
+              "message": [
+                {
+                  "instruction": "stop"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/back-end/resources/testing/test_doubleEvent.json
+++ b/back-end/resources/testing/test_doubleEvent.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/test_resolveFalse.json
+++ b/back-end/resources/testing/test_resolveFalse.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },
@@ -121,7 +121,7 @@
       "description": "device that has all types of input",
       "input": {
         "numeric": "numeric",
-        "boolean":"boolean",
+        "boolean": "boolean",
         "string": "string",
         "array": "array",
         "custom": "custom"
@@ -219,7 +219,8 @@
                     }
                   ]
                 }
-              },               {
+              },
+              {
                 "type": "device",
                 "type_id": "controlBoard",
                 "constraints": {
@@ -341,13 +342,26 @@
           "description": "Als de knop omgaat, stopt het spel.",
           "limit": 1,
           "conditions": {
-            "type": "device",
-            "type_id": "controlBoard",
-            "constraints": {
-              "comparison": "eq",
-              "value": true,
-              "component_id": "mainSwitch"
-            }
+            "operator": "OR",
+            "list": [
+              {
+                "type": "device",
+                "type_id": "controlBoard",
+                "constraints": {
+                  "comparison": "eq",
+                  "value": true,
+                  "component_id": "mainSwitch"
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "telephoneRings",
+                "constraints": {
+                  "comparison": "eq",
+                  "value": 1
+                }
+              }
+            ]
           },
           "actions": [
             {

--- a/back-end/resources/testing/test_resolveTrue.json
+++ b/back-end/resources/testing/test_resolveTrue.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },
@@ -313,6 +313,14 @@
                       "value": true
                     }
                   ]
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "flipSwitch",
+                "constraints": {
+                  "comparison": "eq",
+                  "value": 1
                 }
               }
             ]

--- a/back-end/resources/testing/test_singleEvent.json
+++ b/back-end/resources/testing/test_singleEvent.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckActionArray.json
+++ b/back-end/resources/testing/wrong-types/testCheckActionArray.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckActionBoolean.json
+++ b/back-end/resources/testing/wrong-types/testCheckActionBoolean.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckActionCustom.json
+++ b/back-end/resources/testing/wrong-types/testCheckActionCustom.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckActionString.json
+++ b/back-end/resources/testing/wrong-types/testCheckActionString.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckActionWrongComponent.json
+++ b/back-end/resources/testing/wrong-types/testCheckActionWrongComponent.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckActionWrongDevice.json
+++ b/back-end/resources/testing/wrong-types/testCheckActionWrongDevice.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckActionWrongInstruction.json
+++ b/back-end/resources/testing/wrong-types/testCheckActionWrongInstruction.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckActionWrongType.json
+++ b/back-end/resources/testing/wrong-types/testCheckActionWrongType.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckComparisonPerType.json
+++ b/back-end/resources/testing/wrong-types/testCheckComparisonPerType.json
@@ -36,13 +36,10 @@
       "id": "controlBoard",
       "description": "Control board with three switches, three slides with lights and one main switch.",
       "input": {
-        "redSwitch": "boolean",
-        "orangeSwitch": "boolean",
-        "greenSwitch": "boolean",
-        "slider1": "numeric",
-        "slider2": "numeric",
-        "slider3": "numeric",
-        "mainSwitch": "boolean"
+        "array": "array",
+        "numeric": "numeric",
+        "string": "string",
+        "boolean": "boolean"
       },
       "output": {
         "greenLight1": {
@@ -121,7 +118,7 @@
       "description": "device that has all types of input",
       "input": {
         "numeric": "numeric",
-        "boolean":"boolean",
+        "boolean": "boolean",
         "string": "string",
         "array": "array",
         "custom": "custom"
@@ -159,7 +156,7 @@
                 {
                   "component_id": "greenLight1",
                   "instruction": "interval",
-                  "value": [true, true, false, "string"]
+                  "value": 0.5
                 },
                 {
                   "component_id": "greenLight1",
@@ -198,26 +195,34 @@
                   "operator": "OR",
                   "list": [
                     {
-                      "component_id": "mainSwitch",
-                      "comparison": "eq",
+                      "component_id": "boolean",
+                      "comparison": "unknown",
                       "value": true
                     },
                     {
-                      "component_id": "greenSwitch",
-                      "comparison": "eq",
-                      "value": true
+                      "component_id": "string",
+                      "comparison": "unknown",
+                      "value": "test"
                     },
                     {
-                      "component_id": "redSwitch",
-                      "comparison": "eq",
-                      "value": true
+                      "component_id": "numeric",
+                      "comparison": "unknown",
+                      "value": 10
                     },
                     {
-                      "component_id": "slider2",
-                      "comparison": "lt",
-                      "value": 20
+                      "component_id": "array",
+                      "comparison": "unknown",
+                      "value": [20]
                     }
                   ]
+                }
+              },
+              {
+                "type": "rule",
+                "type_id": "correctSequence",
+                "constraints": {
+                  "comparison": "unknown",
+                  "value": 2
                 }
               }
             ]
@@ -296,8 +301,8 @@
                   "operator": "AND",
                   "list": [
                     {
-                      "comparison": "eq",
-                      "value": "00:01:01"
+                      "comparison": "unknown",
+                      "value": true
                     }
                   ]
                 }

--- a/back-end/resources/testing/wrong-types/testCheckConstraintInputArray.json
+++ b/back-end/resources/testing/wrong-types/testCheckConstraintInputArray.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckConstraintInputArrayComparison.json
+++ b/back-end/resources/testing/wrong-types/testCheckConstraintInputArrayComparison.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckConstraintInputBool.json
+++ b/back-end/resources/testing/wrong-types/testCheckConstraintInputBool.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckConstraintInputBoolComparison.json
+++ b/back-end/resources/testing/wrong-types/testCheckConstraintInputBoolComparison.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckConstraintInputCustom.json
+++ b/back-end/resources/testing/wrong-types/testCheckConstraintInputCustom.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckConstraintInputNumeric.json
+++ b/back-end/resources/testing/wrong-types/testCheckConstraintInputNumeric.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckConstraintInputNumericComparison.json
+++ b/back-end/resources/testing/wrong-types/testCheckConstraintInputNumericComparison.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckConstraintInputString.json
+++ b/back-end/resources/testing/wrong-types/testCheckConstraintInputString.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckConstraintInputStringComparison.json
+++ b/back-end/resources/testing/wrong-types/testCheckConstraintInputStringComparison.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckRuleComparison.json
+++ b/back-end/resources/testing/wrong-types/testCheckRuleComparison.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckRuleID.json
+++ b/back-end/resources/testing/wrong-types/testCheckRuleID.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/resources/testing/wrong-types/testCheckRuleValue.json
+++ b/back-end/resources/testing/wrong-types/testCheckRuleValue.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name": "Escape X",
-    "duration": "00:30:00",
+    "duration": "30m",
     "host": "localhost",
     "port": 1883
   },

--- a/back-end/src/sciler/config/configHandler.go
+++ b/back-end/src/sciler/config/configHandler.go
@@ -15,22 +15,26 @@ func ReadFile(filename string) WorkingConfig {
 	if err != nil {
 		panic(errors.New("Could not read file " + filename).Error())
 	}
-	config := ReadJSON(dat)
+	config, errorList := ReadJSON(dat)
+	if len(errorList) > 0 {
+		panic(errors.New(errorList[0]))
+	}
 	return config
 }
 
 // ReadJSON transforms json file into config object.
-func ReadJSON(input []byte) WorkingConfig {
+func ReadJSON(input []byte) (WorkingConfig, []string) {
 	var config ReadConfig
+	errorList := make([]string, 0)
 	jsonErr := json.Unmarshal(input, &config)
 	if jsonErr != nil {
-		panic(jsonErr.Error())
+		errorList = append(errorList, jsonErr.Error())
 	}
 	newConfig, configErr := generateDataStructures(config)
 	if configErr != nil {
-		panic(configErr.Error())
+		errorList = append(errorList, configErr.Error())
 	}
-	return newConfig
+	return newConfig, errorList
 }
 
 // Creates additional structures: forms device and rule maps;

--- a/back-end/src/sciler/config/configHandler.go
+++ b/back-end/src/sciler/config/configHandler.go
@@ -22,7 +22,6 @@ func ReadFile(filename string) WorkingConfig {
 	if len(errorList) > 0 {
 		panic(errorList[0])
 	}
-	// TODO return config, errorList
 	return config
 }
 

--- a/back-end/src/sciler/config/configHandler.go
+++ b/back-end/src/sciler/config/configHandler.go
@@ -15,9 +15,13 @@ func ReadFile(filename string) WorkingConfig {
 	errorList := make([]string, 0)
 	if err != nil {
 		errorList = append(errorList, errors.New("Could not read file "+filename).Error())
+		panic(errorList[0])
 	}
 	config, jsonErrors := ReadJSON(dat)
 	errorList = append(errorList, jsonErrors...)
+	if len(errorList) > 0 {
+		panic(errorList[0])
+	}
 	// TODO return config, errorList
 	return config
 }
@@ -41,8 +45,12 @@ func generateDataStructures(readConfig ReadConfig) (WorkingConfig, []string) {
 	// Copy information from read config to working config.
 	config.General = readConfig.General
 	config.Cameras = readConfig.Cameras
-	config.Puzzles = generatePuzzles(readConfig.Puzzles, &config)
-	config.GeneralEvents = generateGeneralEvents(readConfig.GeneralEvents, &config)
+	newPuzzles, puzzleErrors := generatePuzzles(readConfig.Puzzles, &config)
+	config.Puzzles = newPuzzles
+	newEvents, eventErrors := generateGeneralEvents(readConfig.GeneralEvents, &config)
+	config.GeneralEvents = newEvents
+	errorList = append(errorList, append(puzzleErrors, eventErrors...)...)
+
 	config.Devices = make(map[string]*Device)
 	for _, readDevice := range readConfig.Devices {
 		config.Devices[readDevice.ID] = &(Device{readDevice.ID, readDevice.Description, readDevice.Input,
@@ -58,19 +66,28 @@ func generateDataStructures(readConfig ReadConfig) (WorkingConfig, []string) {
 	})
 	config.Timers = make(map[string]*Timer)
 	for _, readTimer := range readConfig.Timers {
-		duration, ok := time.ParseDuration(readTimer.Duration)
-		if ok == nil {
-			config.Timers[readTimer.ID] = newTimer(readTimer.ID, duration)
+		duration, err := time.ParseDuration(readTimer.Duration)
+		if err != nil {
+			errorList = append(errorList, err.Error())
 		} else {
-			errorList = append(errorList, errors.New("Could not parse duration of timer: "+readTimer.ID).Error())
+			config.Timers[readTimer.ID] = newTimer(readTimer.ID, duration)
 		}
 	}
-	duration, _ := time.ParseDuration(config.General.Duration)
-	config.Timers["general"] = newTimer("general", duration)
-	config.StatusMap = generateStatusMap(&config)
-	config.RuleMap = generateRuleMap(&config)
-
-	return config, append(errorList, checkConfig(config)...)
+	duration, err := time.ParseDuration(config.General.Duration)
+	if err != nil {
+		errorList = append(errorList, err.Error())
+	} else {
+		config.Timers["general"] = newTimer("general", duration)
+	}
+	if len(errorList) == 0 {
+		// if there are errors in config format,
+		// wait with creating maps (which use condition type ids)
+		// and with checking constraint
+		config.StatusMap = generateStatusMap(&config)
+		config.RuleMap = generateRuleMap(&config)
+		errorList = append(errorList, checkConfig(config)...)
+	}
+	return config, errorList
 }
 
 func getAllRules(config *WorkingConfig) []*Rule {
@@ -123,23 +140,19 @@ func checkConfig(config WorkingConfig) []string {
 	errList := make([]string, 0)
 	for _, puzzle := range config.Puzzles {
 		for _, rule := range puzzle.Event.Rules {
-			if err := rule.Conditions.checkConstraints(config); err != nil {
-				errList = append(errList, err.Error())
+			if err := rule.Conditions.checkConstraints(config, rule.ID); err != nil {
+				errList = append(errList, err...)
 			}
-			if err := checkActions(rule.Actions, config); err != nil {
-				errList = append(errList, err.Error())
-			}
+			errList = append(errList, checkActions(rule.Actions, config)...)
 		}
 	}
 
 	for _, generalEvent := range config.GeneralEvents {
 		for _, rule := range generalEvent.Rules {
-			if err := rule.Conditions.checkConstraints(config); err != nil {
-				errList = append(errList, err.Error())
+			if err := rule.Conditions.checkConstraints(config, rule.ID); err != nil {
+				errList = append(errList, err...)
 			}
-			if err := checkActions(rule.Actions, config); err != nil {
-				errList = append(errList, err.Error())
-			}
+			errList = append(errList, checkActions(rule.Actions, config)...)
 		}
 	}
 	// todo check uniqueness of all device_id, timer_id and rule_id
@@ -147,44 +160,45 @@ func checkConfig(config WorkingConfig) []string {
 }
 
 // checkAction is a method that will return an error is the actions value types and instructions are not equal to the device output specifications
-func checkActions(actions []Action, config WorkingConfig) error {
+func checkActions(actions []Action, config WorkingConfig) []string {
+	errorList := make([]string, 0)
 	for _, action := range actions {
 		switch action.Type {
 		case "device":
 			{
-				if err := checkActionDevice(action, config); err != nil {
-					return err
-				}
+				errorList = append(errorList, checkActionDevice(action, config)...)
 			}
 		case "timer":
-			if err := checkActionTimer(action, config); err != nil {
-				return err
-			}
-
+			errorList = append(errorList, checkActionTimer(action, config)...)
 		default:
-			return fmt.Errorf("only device and timer are accepted as type for an action, however type was specified as: %s", action.Type)
+			errorList = append(errorList,
+				fmt.Sprintf("only device and timer are accepted as type for an action, however type was specified as: %s", action.Type))
 		}
 	}
-	return nil
+	return errorList
 }
 
-func checkActionTimer(action Action, config WorkingConfig) error {
+func checkActionTimer(action Action, config WorkingConfig) []string {
+	errorList := make([]string, 0)
 	if _, ok := config.Timers[action.TypeID]; ok { // checks if timer can be found in the map, if so, it is stored in variable device
 		for _, actionMessage := range action.Message {
 			if actionMessage.Instruction == "add" || actionMessage.Instruction == "subtract" {
 				valueType := reflect.TypeOf(actionMessage.Value).Kind()
 				if valueType != reflect.String {
-					return fmt.Errorf("input type string expected but %s found as type of value %v", valueType.String(), actionMessage.Value)
+					errorList = append(errorList,
+						fmt.Sprintf("input type string expected but %s found as type of value %v",
+							valueType.String(), actionMessage.Value))
 				}
 			}
 		}
 	} else {
-		return fmt.Errorf("timer with id %s not found in map", action.TypeID)
+		errorList = append(errorList, fmt.Sprintf("timer with id %s not found in map", action.TypeID))
 	}
-	return nil
+	return errorList
 }
 
-func checkActionDevice(action Action, config WorkingConfig) error {
+func checkActionDevice(action Action, config WorkingConfig) []string {
+	errorList := make([]string, 0)
 	if device, ok := config.Devices[action.TypeID]; ok { // checks if device can be found in the map, if so, it is stored in variable device
 		for _, actionMessage := range action.Message {
 			if outputObject, ok := device.Output[actionMessage.ComponentID]; ok {
@@ -194,73 +208,93 @@ func checkActionDevice(action Action, config WorkingConfig) error {
 					case "string":
 						{
 							if valueType != reflect.String {
-								return fmt.Errorf("instruction type string expected but %s found as type of value %v", valueType.String(), actionMessage.Value)
+								errorList = append(errorList,
+									fmt.Sprintf("instruction type string expected but %s found as type of value %v",
+										valueType.String(), actionMessage.Value))
 							}
 						}
 					case "boolean":
 						{
 							if valueType != reflect.Bool {
-								return fmt.Errorf("instruction type boolean expected but %s found as type of value %v", valueType.String(), actionMessage.Value)
+								errorList = append(errorList,
+									fmt.Sprintf("instruction type boolean expected but %s found as type of value %v",
+										valueType.String(), actionMessage.Value))
 							}
 						}
 					case "numeric":
 						{
 							if valueType != reflect.Int && valueType != reflect.Float64 {
-								return fmt.Errorf("instruction type numeric expected but %s found as type of value %v", valueType.String(), actionMessage.Value)
+								errorList = append(errorList,
+									fmt.Sprintf("instruction type numeric expected but %s found as type of value %v",
+										valueType.String(), actionMessage.Value))
 							}
 						}
 					case "array":
 						{
 							if valueType != reflect.Slice {
-								return fmt.Errorf("instruction type array/slice expected but %s found as type of value %v", valueType.String(), actionMessage.Value)
+								errorList = append(errorList,
+									fmt.Sprintf("instruction type array/slice expected but %s found as type of value %v",
+										valueType.String(), actionMessage.Value))
 							}
 						}
 					default:
 						// todo custom types
-						return fmt.Errorf("custom types like: %s, are not yet implemented", instructionType)
+						errorList = append(errorList,
+							fmt.Sprintf("custom types like: %s, are not yet implemented", instructionType))
 					}
 				} else {
-					return fmt.Errorf("instruction %s not found in map", actionMessage.Instruction)
+					errorList = append(errorList,
+						fmt.Sprintf("instruction %s not found in map", actionMessage.Instruction))
 				}
 			} else {
-				return fmt.Errorf("component with id %s not found in map", actionMessage.ComponentID)
+				errorList = append(errorList,
+					fmt.Sprintf("component with id %s not found in map", actionMessage.ComponentID))
 			}
 		}
 	} else {
-		return fmt.Errorf("device with id %s not found in map", action.TypeID)
+		errorList = append(errorList,
+			fmt.Sprintf("device with id %s not found in map", action.TypeID))
 	}
-	return nil
+	return errorList
 }
 
-func generatePuzzles(readPuzzles []ReadPuzzle, config *WorkingConfig) []*Puzzle {
+func generatePuzzles(readPuzzles []ReadPuzzle, config *WorkingConfig) ([]*Puzzle, []string) {
 	var result []*Puzzle
+	errorList := make([]string, 0)
 	for _, readPuzzle := range readPuzzles {
+		event, newErrors := generateGeneralEvent(readPuzzle, config)
 		puzzle := Puzzle{
-			Event: generateGeneralEvent(readPuzzle, config),
+			Event: event,
 			Hints: readPuzzle.Hints,
 		}
 		result = append(result, &puzzle)
+		errorList = append(errorList, newErrors...)
 	}
-	return result
+	return result, errorList
 }
 
-func generateGeneralEvents(readGeneralEvents []ReadGeneralEvent, config *WorkingConfig) []*GeneralEvent {
+func generateGeneralEvents(readGeneralEvents []ReadGeneralEvent, config *WorkingConfig) ([]*GeneralEvent, []string) {
 	var result []*GeneralEvent
+	errorList := make([]string, 0)
 	for _, readGeneralEvent := range readGeneralEvents {
-		result = append(result, generateGeneralEvent(readGeneralEvent, config))
+		newResult, newErrors := generateGeneralEvent(readGeneralEvent, config)
+		result = append(result, newResult)
+		errorList = append(errorList, newErrors...)
 	}
-	return result
+	return result, errorList
 }
 
-func generateGeneralEvent(event ReadEvent, config *WorkingConfig) *GeneralEvent {
+func generateGeneralEvent(event ReadEvent, config *WorkingConfig) (*GeneralEvent, []string) {
+	rules, errorList := generateRules(event.GetRules(), config)
 	return &GeneralEvent{
 		Name:  event.GetName(),
-		Rules: generateRules(event.GetRules(), config),
-	}
+		Rules: rules,
+	}, errorList
 }
 
-func generateRules(readRules []ReadRule, config *WorkingConfig) []*Rule {
+func generateRules(readRules []ReadRule, config *WorkingConfig) ([]*Rule, []string) {
 	var rules []*Rule
+	errorList := make([]string, 0)
 	for _, readRule := range readRules {
 		rule := Rule{
 			ID:          readRule.ID,
@@ -270,59 +304,74 @@ func generateRules(readRules []ReadRule, config *WorkingConfig) []*Rule {
 			Conditions:  nil,
 			Actions:     readRule.Actions,
 		}
-		rule.Conditions = generateLogicalCondition(readRule.Conditions)
+		conditions, newErrors := generateLogicalCondition(readRule.Conditions)
+		rule.Conditions = conditions
+		errorList = append(errorList, newErrors...)
 		rules = append(rules, &rule)
 	}
-	return rules
+	return rules, errorList
 }
 
-func generateLogicalCondition(conditions interface{}) LogicalCondition {
+func generateLogicalCondition(conditions interface{}) (LogicalCondition, []string) {
 	logic := conditions.(map[string]interface{})
+	errorList := make([]string, 0)
 	if logic["operator"] != nil { // operator
 		if logic["operator"] == "AND" {
 			and := AndCondition{}
 			for _, condition := range logic["list"].([]interface{}) {
-				and.logics = append(and.logics, generateLogicalCondition(condition))
+				newCondition, newErrors := generateLogicalCondition(condition)
+				and.logics = append(and.logics, newCondition)
+				errorList = append(errorList, newErrors...)
 			}
-			return and
+			return and, errorList
 		} else if logic["operator"] == "OR" {
 			or := OrCondition{}
 			for _, condition := range logic["list"].([]interface{}) {
-				or.logics = append(or.logics, generateLogicalCondition(condition))
+				newCondition, newErrors := generateLogicalCondition(condition)
+				or.logics = append(or.logics, newCondition)
+				errorList = append(errorList, newErrors...)
 			}
-			return or
+			return or, errorList
 		} else {
-			panic(fmt.Sprintf("JSON config in wrong format, operator: %v, could not be processed", logic["operator"]))
+			return nil, append(errorList,
+				fmt.Sprintf("JSON config in wrong format, operator: %v, could not be processed", logic["operator"]))
 		}
 	} else if logic["type"] != nil && reflect.TypeOf(logic["type"]).Kind() == reflect.String && logic["type_id"] != nil && reflect.TypeOf(logic["type_id"]).Kind() == reflect.String {
+		constraints, newErrors := generateLogicalConstraint(logic["constraints"])
 		condition := Condition{
 			Type:        logic["type"].(string),
 			TypeID:      logic["type_id"].(string),
-			Constraints: generateLogicalConstraint(logic["constraints"]),
+			Constraints: constraints,
 		}
-
-		return condition
+		return condition, append(errorList, newErrors...)
 	}
-	panic(fmt.Sprintf("JSON config in wrong condition format, conditions: %v, could not be processed", conditions))
+	return nil, append(errorList,
+		fmt.Sprintf("JSON config in wrong condition format, conditions: %v, could not be processed", conditions))
 }
 
-func generateLogicalConstraint(constraints interface{}) LogicalConstraint {
+func generateLogicalConstraint(constraints interface{}) (LogicalConstraint, []string) {
 	logic := constraints.(map[string]interface{})
+	errorList := make([]string, 0)
 	if logic["operator"] != nil { // operator
 		if logic["operator"] == "AND" {
 			and := AndConstraint{}
 			for _, constraint := range logic["list"].([]interface{}) {
-				and.logics = append(and.logics, generateLogicalConstraint(constraint))
+				newConstraint, newErrors := generateLogicalConstraint(constraint)
+				and.logics = append(and.logics, newConstraint)
+				errorList = append(errorList, newErrors...)
 			}
-			return and
+			return and, errorList
 		} else if logic["operator"] == "OR" {
 			or := OrConstraint{}
 			for _, constraint := range logic["list"].([]interface{}) {
-				or.logics = append(or.logics, generateLogicalConstraint(constraint))
+				newConstraint, newErrors := generateLogicalConstraint(constraint)
+				or.logics = append(or.logics, newConstraint)
+				errorList = append(errorList, newErrors...)
 			}
-			return or
+			return or, errorList
 		} else {
-			panic(fmt.Sprintf("JSON config in wrong format, operator: %v, could not be processed", logic["operator"]))
+			return nil, append(errorList,
+				fmt.Sprintf("JSON config in wrong format, operator: %v, could not be processed", logic["operator"]))
 		}
 	} else if logic["comparison"] != nil && reflect.TypeOf(logic["comparison"]).Kind() == reflect.String {
 		var constraint Constraint
@@ -339,10 +388,13 @@ func generateLogicalConstraint(constraints interface{}) LogicalConstraint {
 				Value:       logic["value"],
 			}
 		} else {
-			panic(fmt.Sprintf("JSON config in wrong format, component_id should be of type string, %v is of type %s", logic["component_id"], reflect.TypeOf(logic["component_id"]).Kind().String()))
+			errorList = append(errorList,
+				fmt.Sprintf("JSON config in wrong format, component_id should be of type string, %v is of type %s",
+					logic["component_id"], reflect.TypeOf(logic["component_id"]).Kind().String()))
 		}
 
-		return constraint
+		return constraint, errorList
 	}
-	panic(fmt.Sprintf("JSON config in wrong constraint format, conditions: %v, could not be processed", constraints))
+	return nil, append(errorList,
+		fmt.Sprintf("JSON config in wrong constraint format, conditions: %v, could not be processed", constraints))
 }

--- a/back-end/src/sciler/config/configHandler_test.go
+++ b/back-end/src/sciler/config/configHandler_test.go
@@ -21,6 +21,30 @@ func TestDurationError(t *testing.T) {
 		"Incorrect json (duration in int) should panic")
 }
 
+func TestDurationErrorWrongFormat(t *testing.T) {
+	filename := "../../../resources/testing/testDurationErrorWrongFormat.json"
+	assert.PanicsWithValue(t,
+		"time: missing unit in duration 30",
+		func() { ReadFile(filename) },
+		"Incorrect json (duration without unit specification) should panic")
+}
+
+func TestDurationTimerError(t *testing.T) {
+	filename := "../../../resources/testing/testDurationTimerError.json"
+	assert.PanicsWithValue(t,
+		"json: cannot unmarshal number into Go struct field ReadTimer.timers.duration of type string",
+		func() { ReadFile(filename) },
+		"Incorrect json (timer duration in int) should panic")
+}
+
+func TestDurationTimerErrorWrongFormat(t *testing.T) {
+	filename := "../../../resources/testing/testDurationTimerErrorWrongFormat.json"
+	assert.PanicsWithValue(t,
+		"time: unknown unit x in duration 10x",
+		func() { ReadFile(filename) },
+		"Incorrect json (timer duration with incorrect unit specification) should panic")
+}
+
 func TestDeviceInputWrongTypeError(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testDeviceInputWrongTypeError.json"
 	assert.PanicsWithValue(t,
@@ -37,7 +61,7 @@ func TestReadFile(t *testing.T) {
 func TestDeviceConstraintNotPresent(t *testing.T) {
 	filename := "../../../resources/testing/testDeviceConstraintNotPresent.json"
 	assert.PanicsWithValue(t,
-		"device with id non existing not found in map",
+		"on rule flipSwitch: device with id non existing not found in map",
 		func() { ReadFile(filename) },
 		"ReadDevice used in constraint should be present in device logics")
 }
@@ -45,7 +69,7 @@ func TestDeviceConstraintNotPresent(t *testing.T) {
 func TestComponentConstraintNotPresent(t *testing.T) {
 	filename := "../../../resources/testing/testComponentConstraintNotPresent.json"
 	assert.PanicsWithValue(t,
-		"component with id non existing not found in map",
+		"on rule correctSequence: component with id non existing not found in map",
 		func() { ReadFile(filename) },
 		"Component used in constraint should be present in device logics")
 }
@@ -53,7 +77,7 @@ func TestComponentConstraintNotPresent(t *testing.T) {
 func TestIncorrectTypeCondition(t *testing.T) {
 	filename := "../../../resources/testing/testIncorrectTypeCondition.json"
 	assert.PanicsWithValue(t,
-		"invalid type of condition: not device or timer",
+		"on rule correctSequence: invalid type of condition: not device or timer",
 		func() { ReadFile(filename) },
 		"ReadCondition type should be 'device' or 'timer'")
 }

--- a/back-end/src/sciler/config/readConfigTypes.go
+++ b/back-end/src/sciler/config/readConfigTypes.go
@@ -116,7 +116,7 @@ func (action Action) Execute(handler InstructionSender) {
 	switch action.Type { // this cannot be any other Type than device or timer, (checked in checkActions function)
 	case "device":
 		{
-			handler.SendInstruction(action.TypeID, action.Message)
+			handler.SendComponentInstruction(action.TypeID, action.Message)
 		}
 	case "timer":
 		{

--- a/back-end/src/sciler/config/readConfigTypes.go
+++ b/back-end/src/sciler/config/readConfigTypes.go
@@ -111,6 +111,7 @@ type Action struct {
 }
 
 // Execute is a method that performs the action
+// TODO test this
 func (action Action) Execute(handler InstructionSender) {
 	switch action.Type { // this cannot be any other Type than device or timer, (checked in checkActions function)
 	case "device":

--- a/back-end/src/sciler/config/workingConfigTypes.go
+++ b/back-end/src/sciler/config/workingConfigTypes.go
@@ -37,7 +37,7 @@ func newTimer(id string, d time.Duration) *Timer {
 	t.Duration = d
 	t.Finish = false
 	t.State = "stateIdle"
-	t.Ending = func() {
+	t.Ending = func() { // TODO test
 		t.State = "stateExpired"
 		t.Finish = true
 	}
@@ -79,7 +79,7 @@ func (t *Timer) Pause() bool {
 	if t.State != "stateActive" {
 		return false
 	}
-	if !t.T.Stop() {
+	if !t.T.Stop() { //TODO test
 		t.State = "stateExpired"
 		return false
 	}
@@ -188,17 +188,17 @@ func compare(param1 interface{}, param2 interface{}, comparision string) bool {
 	switch comparision {
 	case "eq":
 		if reflect.TypeOf(param1).Kind() == reflect.Int || reflect.TypeOf(param2).Kind() == reflect.Int {
-			return NumericToFloat64(param1) == NumericToFloat64(param2)
+			return numericToFloat64(param1) == numericToFloat64(param2)
 		}
 		return reflect.DeepEqual(param1, param2)
 	case "lt":
-		return NumericToFloat64(param1) < NumericToFloat64(param2)
+		return numericToFloat64(param1) < numericToFloat64(param2)
 	case "gt":
-		return NumericToFloat64(param1) > NumericToFloat64(param2)
+		return numericToFloat64(param1) > numericToFloat64(param2)
 	case "lte":
-		return NumericToFloat64(param1) <= NumericToFloat64(param2)
+		return numericToFloat64(param1) <= numericToFloat64(param2)
 	case "gte":
-		return NumericToFloat64(param1) >= NumericToFloat64(param2)
+		return numericToFloat64(param1) >= numericToFloat64(param2)
 	case "contains":
 		return contains(param1, param2)
 	default:
@@ -207,8 +207,8 @@ func compare(param1 interface{}, param2 interface{}, comparision string) bool {
 	}
 }
 
-// NumericToFloat64 checks if numeric value is in or float64 and returns float64
-func NumericToFloat64(input interface{}) float64 {
+// numericToFloat64 checks if numeric value is in or float64 and returns float64
+func numericToFloat64(input interface{}) float64 {
 	switch input.(type) {
 	case float64:
 		return input.(float64)

--- a/back-end/src/sciler/config/workingConfigTypes.go
+++ b/back-end/src/sciler/config/workingConfigTypes.go
@@ -114,7 +114,7 @@ type Rule struct {
 
 // InstructionSender is an interface needed for preventing cyclic imports
 type InstructionSender interface {
-	SendInstruction(string, []ComponentInstruction)
+	SendComponentInstruction(string, []ComponentInstruction)
 	SetTimer(string, ComponentInstruction)
 	HandleEvent(string)
 }

--- a/back-end/src/sciler/config/workingConfigTypes_test.go
+++ b/back-end/src/sciler/config/workingConfigTypes_test.go
@@ -545,6 +545,6 @@ func Test_CheckTimerID(t *testing.T) {
 }
 
 func TestNumericToFloatNonNumeric(t *testing.T) {
-	assert.Equal(t, float64(0), NumericToFloat64("0"),
+	assert.Equal(t, float64(0), numericToFloat64("0"),
 		"non input or float value should return 0")
 }

--- a/back-end/src/sciler/config/workingConfigTypes_test.go
+++ b/back-end/src/sciler/config/workingConfigTypes_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -29,6 +28,7 @@ func TestGeneralEvent_GetRules(t *testing.T) {
 	assert.Equal(t, generalEvent.GetRules(), []*Rule{rule})
 }
 
+// TODO Test last timer parts: t.Ending() and t.Stop()
 func TestTimer_GetTimeLeft(t *testing.T) {
 	timer := Timer{
 		ID:        "testTimer",
@@ -183,17 +183,22 @@ func TestPuzzle_GetRules(t *testing.T) {
 }
 
 func Test_CompareWrongComparison(t *testing.T) {
-	assert.PanicsWithValue(t,
-		"cannot compare on: unknown",
-		func() { compare("a", "a", "unknown") },
+	assert.False(t, compare("a", "a", "unknown"),
 		"comparisons should be done on existing options like eq and gte")
+}
+
+func Test_CompareWrongComparisonPerType(t *testing.T) {
+	filename := "../../../resources/testing/wrong-types/testCheckComparisonPerType.json"
+	assert.Panics(t,
+		func() { ReadFile(filename) },
+		"The comparison in a constraint on a condition of type rule may only be a numeric comparator")
 }
 
 func Test_compare(t *testing.T) {
 	type args struct {
-		param1      interface{}
-		param2      interface{}
-		comparision string
+		param1     interface{}
+		param2     interface{}
+		comparison string
 	}
 	tests := []struct {
 		name string
@@ -203,145 +208,145 @@ func Test_compare(t *testing.T) {
 		{
 			name: "equal false",
 			args: args{
-				param1:      float64(1),
-				param2:      float64(2),
-				comparision: "eq",
+				param1:     float64(1),
+				param2:     float64(2),
+				comparison: "eq",
 			},
 			want: false,
 		}, {
 			name: "equal true",
 			args: args{
-				param1:      float64(2),
-				param2:      float64(2),
-				comparision: "eq",
+				param1:     float64(2),
+				param2:     float64(2),
+				comparison: "eq",
 			},
 			want: true,
 		}, {
 			name: "equal true int 2 == float62(2)",
 			args: args{
-				param1:      2, // int
-				param2:      float64(2),
-				comparision: "eq",
+				param1:     2, // int
+				param2:     float64(2),
+				comparison: "eq",
 			},
 			want: true,
 		}, {
 			name: "less then false",
 			args: args{
-				param1:      float64(1),
-				param2:      float64(1),
-				comparision: "lt",
+				param1:     float64(1),
+				param2:     float64(1),
+				comparison: "lt",
 			},
 			want: false,
 		}, {
 			name: "less then true",
 			args: args{
-				param1:      float64(1),
-				param2:      float64(2),
-				comparision: "lt",
+				param1:     float64(1),
+				param2:     float64(2),
+				comparison: "lt",
 			},
 			want: true,
 		}, {
 			name: "greater then false",
 			args: args{
-				param1:      float64(1),
-				param2:      float64(1),
-				comparision: "gt",
+				param1:     float64(1),
+				param2:     float64(1),
+				comparison: "gt",
 			},
 			want: false,
 		},
 		{
 			name: "greater then true",
 			args: args{
-				param1:      float64(2),
-				param2:      float64(1),
-				comparision: "gt",
+				param1:     float64(2),
+				param2:     float64(1),
+				comparison: "gt",
 			},
 			want: true,
 		}, {
 			name: "less then equal false",
 			args: args{
-				param1:      float64(2),
-				param2:      float64(1),
-				comparision: "lte",
+				param1:     float64(2),
+				param2:     float64(1),
+				comparison: "lte",
 			},
 			want: false,
 		}, {
 			name: "less then equal true1",
 			args: args{
-				param1:      float64(1),
-				param2:      float64(1),
-				comparision: "lte",
+				param1:     float64(1),
+				param2:     float64(1),
+				comparison: "lte",
 			},
 			want: true,
 		}, {
 			name: "less then equal true2",
 			args: args{
-				param1:      float64(1),
-				param2:      float64(2),
-				comparision: "lte",
+				param1:     float64(1),
+				param2:     float64(2),
+				comparison: "lte",
 			},
 			want: true,
 		}, {
 			name: "greater then equal false",
 			args: args{
-				param1:      float64(1),
-				param2:      float64(2),
-				comparision: "gte",
+				param1:     float64(1),
+				param2:     float64(2),
+				comparison: "gte",
 			},
 			want: false,
 		}, {
 			name: "greater then equal true1",
 			args: args{
-				param1:      float64(1),
-				param2:      float64(1),
-				comparision: "gte",
+				param1:     float64(1),
+				param2:     float64(1),
+				comparison: "gte",
 			},
 			want: true,
 		}, {
 			name: "greater then equal true2",
 			args: args{
-				param1:      float64(2),
-				param2:      float64(1),
-				comparision: "gte",
+				param1:     float64(2),
+				param2:     float64(1),
+				comparison: "gte",
 			},
 			want: true,
 		}, {
 			name: "contains false",
 			args: args{
-				param1:      []float64{1, 2, 3, 5},
-				param2:      float64(4),
-				comparision: "contains",
+				param1:     []float64{1, 2, 3, 5},
+				param2:     float64(4),
+				comparison: "contains",
 			},
 			want: false,
 		}, {
 			name: "contains true",
 			args: args{
-				param1:      []float64{1, 2, 3, 4, 5},
-				param2:      float64(4),
-				comparision: "contains",
+				param1:     []float64{1, 2, 3, 4, 5},
+				param2:     float64(4),
+				comparison: "contains",
 			},
 			want: true,
 		}, {
 			name: "equals slice true",
 			args: args{
-				param1:      []float64{1, 2, 3, 4, 5},
-				param2:      []float64{1, 2, 3, 4, 5},
-				comparision: "eq",
+				param1:     []float64{1, 2, 3, 4, 5},
+				param2:     []float64{1, 2, 3, 4, 5},
+				comparison: "eq",
 			},
 			want: true,
 		}, {
 			name: "equals slice false",
 			args: args{
-				param1:      []float64{1, 2, 3, 4, 5},
-				param2:      []float64{1, 2, 3, 5},
-				comparision: "eq",
+				param1:     []float64{1, 2, 3, 4, 5},
+				param2:     []float64{1, 2, 3, 5},
+				comparison: "eq",
 			},
 			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := compare(tt.args.param1, tt.args.param2, tt.args.comparision); got != tt.want {
+			if got := compare(tt.args.param1, tt.args.param2, tt.args.comparison); got != tt.want {
 				t.Errorf("compare() = %v, want %v", got, tt.want)
 			}
 		})
@@ -351,7 +356,7 @@ func Test_compare(t *testing.T) {
 func Test_CheckConstraintInputString(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckConstraintInputString.json"
 	assert.PanicsWithValue(t,
-		"input type string expected but float64 found as type of value 1",
+		"on rule controlSwitch: input type string expected but float64 found as type of value 1",
 		func() { ReadFile(filename) },
 		"When input is specified as a string, the value of a condition should be a string in order to be able to do a comparison")
 }
@@ -359,7 +364,7 @@ func Test_CheckConstraintInputString(t *testing.T) {
 func Test_CheckConstraintInputStringComparison(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckConstraintInputStringComparison.json"
 	assert.PanicsWithValue(t,
-		"comparision lte not allowed on a string",
+		"on rule controlSwitch: comparison lte not allowed on a string",
 		func() { ReadFile(filename) },
 		"When input is specified as a string, only eq is allowed as comparison")
 }
@@ -367,7 +372,7 @@ func Test_CheckConstraintInputStringComparison(t *testing.T) {
 func Test_CheckConstraintInputBool(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckConstraintInputBool.json"
 	assert.PanicsWithValue(t,
-		"input type boolean expected but float64 found as type of value 1",
+		"on rule controlSwitch: input type boolean expected but float64 found as type of value 1",
 		func() { ReadFile(filename) },
 		"When input is specified as a bool, the value of a condition should be a bool in order to be able to do a comparison")
 }
@@ -375,7 +380,7 @@ func Test_CheckConstraintInputBool(t *testing.T) {
 func Test_CheckConstraintInputBoolComparison(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckConstraintInputBoolComparison.json"
 	assert.PanicsWithValue(t,
-		"comparision lte not allowed on a boolean",
+		"on rule controlSwitch: comparison lte not allowed on a boolean",
 		func() { ReadFile(filename) },
 		"When input is specified as a bool, only eq is allowed as comparison")
 }
@@ -383,7 +388,7 @@ func Test_CheckConstraintInputBoolComparison(t *testing.T) {
 func Test_CheckConstraintInputNumeric(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckConstraintInputNumeric.json"
 	assert.PanicsWithValue(t,
-		"input type numeric expected but bool found as type of value true",
+		"on rule controlSwitch: input type numeric expected but bool found as type of value true",
 		func() { ReadFile(filename) },
 		"When input is specified as a numeric, the value of a condition should be a numeric in order to be able to do a comparison")
 }
@@ -391,7 +396,7 @@ func Test_CheckConstraintInputNumeric(t *testing.T) {
 func Test_CheckConstraintInputNumericComparison(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckConstraintInputNumericComparison.json"
 	assert.PanicsWithValue(t,
-		"comparision contains not allowed on a numeric",
+		"on rule controlSwitch: comparison contains not allowed on a numeric",
 		func() { ReadFile(filename) },
 		"When input is specified as a numeric, only eq, lt, gt, lte, gte are allowed as comparison")
 }
@@ -399,7 +404,7 @@ func Test_CheckConstraintInputNumericComparison(t *testing.T) {
 func Test_CheckConstraintInputArray(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckConstraintInputArray.json"
 	assert.PanicsWithValue(t,
-		"input type array/slice expected but float64 found as type of value 1",
+		"on rule controlSwitch: input type array/slice expected but float64 found as type of value 1",
 		func() { ReadFile(filename) },
 		"When input is specified as a array, the value of a condition should be an array in order to be able to do a comparison")
 }
@@ -407,7 +412,7 @@ func Test_CheckConstraintInputArray(t *testing.T) {
 func Test_CheckConstraintInputArrayComparison(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckConstraintInputArrayComparison.json"
 	assert.PanicsWithValue(t,
-		"comparision lte not allowed on an array",
+		"on rule controlSwitch: comparison lte not allowed on an array",
 		func() { ReadFile(filename) },
 		"When input is specified as an array, only contains and eq are allowed as comparison")
 }
@@ -415,7 +420,7 @@ func Test_CheckConstraintInputArrayComparison(t *testing.T) {
 func Test_CheckConstraintInputCustom(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckConstraintInputCustom.json"
 	assert.PanicsWithValue(t,
-		"custom types like: custom, are not yet implemented",
+		"on rule controlSwitch: custom types like: custom, are not yet implemented",
 		func() { ReadFile(filename) },
 		"Custom types are not supported yet")
 }
@@ -433,9 +438,7 @@ func Test_CheckResolve(t *testing.T) {
 		Constraints: constraint,
 	}
 	filename := "../../../resources/testing/test_config.json"
-	assert.PanicsWithValue(t,
-		fmt.Sprintf("cannot resolve constraint %v because condition.type is an unknown type, this should already be checked when reading in the JSON", constraint),
-		func() { constraint.Resolve(condition, ReadFile(filename)) },
+	assert.False(t, constraint.Resolve(condition, ReadFile(filename)),
 		"Custom condition types are not supported!")
 }
 
@@ -472,6 +475,19 @@ func Test_ResolveTimerFalse(t *testing.T) {
 	assert.True(t, config.GeneralEvents[0].GetRules()[0].Conditions.Resolve(config))
 }
 
+func Test_ResolveRuleTrue(t *testing.T) {
+	filename := "../../../resources/testing/test_resolveTrue.json"
+	config := ReadFile(filename)
+	config.RuleMap["flipSwitch"].Executed = 1
+	assert.True(t, config.GeneralEvents[0].GetRules()[0].Conditions.Resolve(config))
+}
+
+func Test_ResolveRuleFalse(t *testing.T) {
+	filename := "../../../resources/testing/test_resolveFalse.json"
+	config := ReadFile(filename)
+	assert.False(t, config.GeneralEvents[1].GetRules()[0].Conditions.Resolve(config))
+}
+
 func Test_ReadTimer(t *testing.T) {
 	filename := "../../../resources/testing/test_config.json"
 	config := ReadFile(filename)
@@ -481,7 +497,7 @@ func Test_ReadTimer(t *testing.T) {
 func Test_CheckRuleValue(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckRuleValue.json"
 	assert.PanicsWithValue(t,
-		"value type numeric expected but bool found as type of value true",
+		"on rule controlSwitch: value type numeric expected but bool found as type of value true",
 		func() { ReadFile(filename) },
 		"The value in a constraint on a condition of type rule may only be of type numeric")
 
@@ -490,7 +506,7 @@ func Test_CheckRuleValue(t *testing.T) {
 func Test_CheckTimerValue(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckTimerValue.json"
 	assert.PanicsWithValue(t,
-		"input type boolean expected but string found as type of value testString",
+		"on rule telephoneRings: input type boolean expected but string found as type of value testString",
 		func() { ReadFile(filename) },
 		"The value in a constraint on a condition of type rule may only be of type bool")
 
@@ -499,7 +515,7 @@ func Test_CheckTimerValue(t *testing.T) {
 func Test_CheckRuleComparison(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckRuleComparison.json"
 	assert.PanicsWithValue(t,
-		"comparision contains not allowed on rule",
+		"on rule controlSwitch: comparison contains not allowed on rule",
 		func() { ReadFile(filename) },
 		"The comparison in a constraint on a condition of type rule may only be a numeric comparator")
 }
@@ -507,7 +523,7 @@ func Test_CheckRuleComparison(t *testing.T) {
 func Test_CheckTimerComparison(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckTimerComparison.json"
 	assert.PanicsWithValue(t,
-		"comparision gte not allowed on a boolean",
+		"on rule telephoneRings: comparison gte not allowed on a boolean",
 		func() { ReadFile(filename) },
 		"The comparison in a constraint on a condition of type rule may only be a numeric comparator")
 }
@@ -515,7 +531,7 @@ func Test_CheckTimerComparison(t *testing.T) {
 func Test_CheckRuleID(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckRuleID.json"
 	assert.PanicsWithValue(t,
-		"rule with id non existing not found in map",
+		"on rule controlSwitch: rule with id non existing not found in map",
 		func() { ReadFile(filename) },
 		"The rule id is unknown")
 }
@@ -523,7 +539,12 @@ func Test_CheckRuleID(t *testing.T) {
 func Test_CheckTimerID(t *testing.T) {
 	filename := "../../../resources/testing/wrong-types/testCheckTimerID.json"
 	assert.PanicsWithValue(t,
-		"timer with id timerTest not found in map",
+		"on rule telephoneRings: timer with id timerTest not found in map",
 		func() { ReadFile(filename) },
 		"The rule id is unknown")
+}
+
+func TestNumericToFloatNonNumeric(t *testing.T) {
+	assert.Equal(t, float64(0), NumericToFloat64("0"),
+		"non input or float value should return 0")
 }

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -346,6 +346,18 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 					jsonMessage, _ := json.Marshal(&message)
 					handler.Communicator.Publish("front-end", string(jsonMessage), 3)
 				}
+			case "use config":
+				{
+					handler.Config, _ = config.ReadJSON([]byte(fmt.Sprintf("%v", instruction["config"])))
+					message := Message{
+						DeviceID: "back-end",
+						TimeSent: time.Now().Format("02-01-2006 15:04:05"),
+						Type:     "new config",
+						Contents: map[string]interface{}{},
+					}
+					jsonMessage, _ := json.Marshal(&message)
+					handler.Communicator.Publish("front-end", string(jsonMessage), 3)
+				}
 			}
 		} else {
 			logrus.Warnf("%s, tried to instruct the back-end, only the front-end is allowed to instruct the back-end", raw.DeviceID)

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -334,6 +334,18 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 					jsonMessage, _ := json.Marshal(&message)
 					handler.Communicator.Publish("front-end", string(jsonMessage), 3)
 				}
+			case "check config":
+				{
+					_, errorList := config.ReadJSON([]byte(fmt.Sprintf("%v", instruction["config"])))
+					message := Message{
+						DeviceID: "back-end",
+						TimeSent: time.Now().Format("02-01-2006 15:04:05"),
+						Type:     "config",
+						Contents: map[string][]string{"errors": errorList},
+					}
+					jsonMessage, _ := json.Marshal(&message)
+					handler.Communicator.Publish("front-end", string(jsonMessage), 3)
+				}
 			}
 		} else {
 			logrus.Warnf("%s, tried to instruct the back-end, only the front-end is allowed to instruct the back-end", raw.DeviceID)

--- a/back-end/src/sciler/handler/handler_helper.go
+++ b/back-end/src/sciler/handler/handler_helper.go
@@ -223,7 +223,7 @@ func (handler *Handler) SetTimer(timerID string, instructions config.ComponentIn
 // If action is "use" then the message must tell the config a new config is now used and put it to use
 func (handler *Handler) processConfig(configToRead interface{}, action string, fileName string) {
 	jsonBytes, err := json.Marshal(configToRead)
-	if err != nil {
+	if err != nil { //TODO test
 		logrus.Error(err)
 	}
 	newConfig, errorList := config.ReadJSON(jsonBytes)
@@ -238,7 +238,7 @@ func (handler *Handler) processConfig(configToRead interface{}, action string, f
 	}
 	if action == "use" && len(errorList) == 0 {
 		dir, dirErr := os.Getwd()
-		if dirErr != nil {
+		if dirErr != nil { //TODO test
 			logrus.Error(dirErr)
 		}
 		fullFileName := filepath.Join(dir, "back-end", "resources", fileName)

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -135,7 +135,7 @@ func TestSendInstruction(t *testing.T) {
 		Contents: inst,
 	})
 	communicatorMock.On("Publish", "display", string(msg), 3)
-	handler.SendInstruction("display", inst)
+	handler.SendComponentInstruction("display", inst)
 	communicatorMock.AssertNumberOfCalls(t, "Publish", 1)
 }
 

--- a/back-end/src/sciler/handler/instruction_test.go
+++ b/back-end/src/sciler/handler/instruction_test.go
@@ -461,17 +461,29 @@ func TestInstructionUseConfig(t *testing.T) {
 		Type:     "instruction",
 		Contents: []map[string]interface{}{{
 			"instruction": "use config",
-			"config":      configToTest},
+			"config":      configToTest,
+			"file":        "new_file.json"},
 		},
 	}
 	returnMsg := Message{
 		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 		Type:     "new config",
-		Contents: map[string]interface{}{},
+		Contents: map[string]interface{}{"name": "new_file.json"},
 	}
+	timerGeneralMessage, _ := json.Marshal(Message{
+		DeviceID: "back-end",
+		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
+		Type:     "time",
+		Contents: map[string]interface{}{
+			"state":    "stateIdle",
+			"duration": 1800000,
+			"id":       "general",
+		},
+	})
 	jsonMessage, _ := json.Marshal(&returnMsg)
+	communicatorMock.On("Publish", "front-end", string(timerGeneralMessage), 3)
 	communicatorMock.On("Publish", "front-end", string(jsonMessage), 3)
 	handler.msgMapper(instructionMsg)
-	communicatorMock.AssertNumberOfCalls(t, "Publish", 1)
+	communicatorMock.AssertNumberOfCalls(t, "Publish", 2)
 }

--- a/back-end/src/sciler/handler/instruction_test.go
+++ b/back-end/src/sciler/handler/instruction_test.go
@@ -363,7 +363,6 @@ func TestOnInstructionMsgMapper(t *testing.T) {
 		"Nothing should have been changed after an instruction message type")
 }
 
-// TODO fix test to pass full config in json message
 func TestInstructionCheckConfigNoErrors(t *testing.T) {
 	communicatorMock := new(CommunicatorMock)
 	fileName := "../../../resources/testing/test_config.json"
@@ -405,14 +404,13 @@ func TestInstructionCheckConfigNoErrors(t *testing.T) {
 
 func TestInstructionCheckConfigWithErrors(t *testing.T) {
 	communicatorMock := new(CommunicatorMock)
-	fileName := "../../../resources/testing/test_config_errors.json"
-	workingConfig := config.ReadFile(fileName)
+	workingConfig := config.ReadFile("../../../resources/testing/test_config.json")
 	handler := Handler{
 		Config:       workingConfig,
-		ConfigFile:   fileName,
+		ConfigFile:   "../../../resources/testing/test_config.json",
 		Communicator: communicatorMock,
 	}
-	jsonFile, _ := ioutil.ReadFile(fileName)
+	jsonFile, _ := ioutil.ReadFile("../../../resources/testing/test_config_errors.json")
 	configToTest := make(map[string]interface{})
 	if err := json.Unmarshal(jsonFile, &configToTest); err != nil {
 		assert.FailNow(t, "cannot create instruction message")
@@ -421,8 +419,9 @@ func TestInstructionCheckConfigWithErrors(t *testing.T) {
 		DeviceID: "front-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 		Type:     "instruction",
-		Contents: []map[string]interface{}{
-			{"instruction": "check config", "config": configToTest},
+		Contents: []map[string]interface{}{{
+			"instruction": "check config",
+			"config":      configToTest},
 		},
 	}
 	returnMsg := Message{
@@ -431,7 +430,8 @@ func TestInstructionCheckConfigWithErrors(t *testing.T) {
 		Type:     "config",
 		Contents: map[string][]string{
 			"errors": {
-				"json: cannot unmarshal number into Go struct field General.general.duration of type string",
+				"time: unknown unit x in duration 10x",
+				"time: missing unit in duration 30",
 			},
 		},
 	}
@@ -459,14 +459,15 @@ func TestInstructionUseConfig(t *testing.T) {
 		DeviceID: "front-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 		Type:     "instruction",
-		Contents: []map[string]interface{}{
-			{"instruction": "use config", "config": configToTest},
+		Contents: []map[string]interface{}{{
+			"instruction": "use config",
+			"config":      configToTest},
 		},
 	}
 	returnMsg := Message{
 		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
-		Type:     "config",
+		Type:     "new config",
 		Contents: map[string]interface{}{},
 	}
 	jsonMessage, _ := json.Marshal(&returnMsg)

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -38,20 +38,19 @@ export class AppComponent implements OnInit, OnDestroy {
   everySecond: Observable<number> = timer(0, 1000);
 
   constructor(private mqttService: MqttService, private snackBar: MatSnackBar) {
-  }
-
-  /**
-   * Initialize app, also called upon loading new config file.
-   */
-  ngOnInit(): void {
     this.jsonConvert = new JsonConvert();
     this.deviceList = new Devices();
     this.puzzleList = new Puzzles();
     this.hintList = [];
     this.configErrorList = [];
     this.cameras = [];
-
     this.timerList = new Timers();
+  }
+
+  /**
+   * Initialize app, also called upon loading new config file.
+   */
+  ngOnInit(): void {
     const generalTimer = { id: "general", duration: 0, state: "stateIdle" };
     this.timerList.setTimer(generalTimer);
 
@@ -207,7 +206,7 @@ export class AppComponent implements OnInit, OnDestroy {
   /**
    * Process instruction messages. Two types exist: reset and status update.
    */
-  public processInstruction(jsonData) {
+  private processInstruction(jsonData) {
     for (const action of jsonData) {
       switch (action.instruction) {
         case "reset": {
@@ -271,18 +270,6 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Opens snackbar with duration of 2 seconds.
-   * @param message displays this message
-   * @param action: button to display
-   */
-  public openSnackbar(message: string, action: string) {
-    const config = new MatSnackBarConfig();
-    config.duration = 3000;
-    config.panelClass = ["custom-snack-bar"];
-    this.snackBar.open(message, action, config);
-  }
-
-  /**
    * Initialize the timers to listen to every second and set their state accordingly.
    */
   private initializeTimers() {
@@ -299,5 +286,17 @@ export class AppComponent implements OnInit, OnDestroy {
         this.timerList.getTimer("general").getTimeLeft()
       );
     });
+  }
+
+  /**
+   * Opens snackbar with duration of 2 seconds.
+   * @param message displays this message
+   * @param action: button to display
+   */
+  public openSnackbar(message: string, action: string) {
+    const config = new MatSnackBarConfig();
+    config.duration = 3000;
+    config.panelClass = ["custom-snack-bar"];
+    this.snackBar.open(message, action, config);
   }
 }

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -25,6 +25,7 @@ export class AppComponent implements OnInit, OnDestroy {
   timerList: Timers;
   cameras: Camera[];
   selectedCamera: string;
+  configErrorList: string[];
 
   constructor(private mqttService: MqttService, private snackBar: MatSnackBar) {
     this.jsonConvert = new JsonConvert();
@@ -160,6 +161,7 @@ export class AppComponent implements OnInit, OnDestroy {
             case "status update": {
               this.sendConnection(true);
             }
+
           }
         }
         break;
@@ -176,6 +178,10 @@ export class AppComponent implements OnInit, OnDestroy {
         for (const obj of msg.contents) {
           this.cameras.push(new Camera(obj));
         }
+        break;
+      }
+      case "config": {
+        this.configErrorList = msg.contents.errors;
         break;
       }
       default:

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -96,7 +96,7 @@ export class AppComponent implements OnInit, OnDestroy {
    * @param instruction instruction to be sent.
    */
   public sendInstruction(instruction: any[]) {
-    let msg = new Message(
+    const msg = new Message(
       "front-end",
       "instruction",
       new Date(),

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -250,6 +250,7 @@ export class AppComponent implements OnInit, OnDestroy {
     }
 
     const rules = jsonData.events;
+    this.puzzleList = new Puzzles();
     for (const rule in rules) {
       if (rules.hasOwnProperty(rule)) {
         this.puzzleList.addPuzzle(rule, rules[rule]);

--- a/front-end/src/app/components/device/device.component.css
+++ b/front-end/src/app/components/device/device.component.css
@@ -14,8 +14,3 @@
     display: none;
   }
 }
-@media only screen and (min-width: 650px) and (max-width: 800px) {
-  .test-column {
-    display: none;
-  }
-}

--- a/front-end/src/app/components/puzzle/puzzle.component.css
+++ b/front-end/src/app/components/puzzle/puzzle.component.css
@@ -11,8 +11,3 @@
     display: none;
   }
 }
-@media only screen and (min-width: 650px) and (max-width: 765px) {
-  .rule-description {
-    display: none;
-  }
-}

--- a/front-end/src/app/config/config.component.css
+++ b/front-end/src/app/config/config.component.css
@@ -1,0 +1,14 @@
+/**'Hide' the actual input and style the label as button**/
+.original-config-button {
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+  padding: 5px;
+  width: 0.1px;
+  height: 0.1px;
+  opacity: 0;
+  overflow: hidden;
+  position: absolute;
+  z-index: -1;
+}
+.config-button {
+  margin-right: 10px;
+}

--- a/front-end/src/app/config/config.component.css
+++ b/front-end/src/app/config/config.component.css
@@ -12,6 +12,8 @@
 .config-button {
   margin-right: 10px;
 }
+
+/*Styling the output box*/
 .file-output-errors {
   background-color: #E68364;
   padding: 5px;
@@ -25,4 +27,9 @@
 }
 .error-list-title {
   font-weight: bold;
+}
+
+/*Minimal height to not shrimp the menu*/
+.config-box {
+  min-height: 155px;
 }

--- a/front-end/src/app/config/config.component.css
+++ b/front-end/src/app/config/config.component.css
@@ -10,7 +10,7 @@
   z-index: -1;
 }
 .config-button {
-  margin-right: 10px;
+  margin: 10px;
 }
 
 /*Styling the output box*/

--- a/front-end/src/app/config/config.component.css
+++ b/front-end/src/app/config/config.component.css
@@ -13,7 +13,6 @@
   margin-right: 10px;
 }
 .file-output {
-  background-color: #E68364;
   padding: 5px;
 }
 .error-list {

--- a/front-end/src/app/config/config.component.css
+++ b/front-end/src/app/config/config.component.css
@@ -12,3 +12,13 @@
 .config-button {
   margin-right: 10px;
 }
+.file-output {
+  background-color: #E68364;
+  padding: 5px;
+}
+.error-list {
+  text-align: left;
+}
+.error-list-title {
+  font-weight: bold;
+}

--- a/front-end/src/app/config/config.component.css
+++ b/front-end/src/app/config/config.component.css
@@ -12,7 +12,12 @@
 .config-button {
   margin-right: 10px;
 }
-.file-output {
+.file-output-errors {
+  background-color: #E68364;
+  padding: 5px;
+}
+.file-output-no-errors {
+  background-color: #87D37C;
   padding: 5px;
 }
 .error-list {

--- a/front-end/src/app/config/config.component.html
+++ b/front-end/src/app/config/config.component.html
@@ -7,13 +7,19 @@
              (change)="checkFile($event.target.files)" >
     </div>
     <p class="uploadString">{{ uploaded }}</p>
-    <div *ngIf="uploaded != ''" class="file-output">
-      <mat-list class="error-list"
-                [ngStyle]="{'background-color' : (getErrors().length == 0)? '#87D37C' :'#E68364'}">
+    <div *ngIf="uploaded != '' && !noErrors" class="file-output-errors">
+      <mat-list class="error-list">
         <mat-list-item class="error-list-title">Errors</mat-list-item>
-        <mat-list-item *ngIf="getErrors().length == 0">Geen errors gevonden!</mat-list-item>
         <mat-list-item *ngFor="let error of getErrors()">{{ error }}</mat-list-item>
       </mat-list>
+    </div>
+    <div *ngIf="noErrors" class="file-output-no-errors">
+      <mat-list class="error-list">
+        <mat-list-item class="error-list-title">Errors</mat-list-item>
+        <mat-list-item>Geen errors gevonden!</mat-list-item>
+      </mat-list>
+      <button class="mat-raised-button mat-primary custom-md-button config-button" (click)="sendConfig()">Gebruik configuratie</button>
+      <p>{{ newConfig }}</p>
     </div>
   </div>
 </div>

--- a/front-end/src/app/config/config.component.html
+++ b/front-end/src/app/config/config.component.html
@@ -1,4 +1,4 @@
-<div class="home-box">
+<div class="home-box config-box">
   <h3 class="header">Configuratie</h3>
   <div class="contents">
     <div class="file-input">

--- a/front-end/src/app/config/config.component.html
+++ b/front-end/src/app/config/config.component.html
@@ -8,9 +8,10 @@
     </div>
     <p class="uploadString">{{ uploaded }}</p>
     <div *ngIf="uploaded != ''" class="file-output">
-      <mat-list class="error-list">
+      <mat-list class="error-list"
+                [ngStyle]="{'background-color' : (getErrors().length == 0)? '#87D37C' :'#E68364'}">
         <mat-list-item class="error-list-title">Errors</mat-list-item>
-        <mat-list-item *ngIf="getErrors().length == 0">No errors found!</mat-list-item>
+        <mat-list-item *ngIf="getErrors().length == 0">Geen errors gevonden!</mat-list-item>
         <mat-list-item *ngFor="let error of getErrors()">{{ error }}</mat-list-item>
       </mat-list>
     </div>

--- a/front-end/src/app/config/config.component.html
+++ b/front-end/src/app/config/config.component.html
@@ -8,9 +8,9 @@
     </div>
     <p class="uploadString">{{ uploaded }}</p>
     <div *ngIf="uploaded != ''" class="file-output">
-      <p>Errors:</p>
-      <p *ngIf="getErrors().length == 0">No errors found!</p>
       <mat-list class="error-list">
+        <mat-list-item class="error-list-title">Errors</mat-list-item>
+        <mat-list-item *ngIf="getErrors().length == 0">No errors found!</mat-list-item>
         <mat-list-item *ngFor="let error of getErrors()">{{ error }}</mat-list-item>
       </mat-list>
     </div>

--- a/front-end/src/app/config/config.component.html
+++ b/front-end/src/app/config/config.component.html
@@ -1,6 +1,18 @@
 <div class="home-box">
   <h3 class="header">Configuratie</h3>
   <div class="contents">
-    <p>config works!</p>
+    <div class="file-input">
+      <label class="mat-raised-button mat-primary custom-md-button config-button" for="inputFile">Upload configuratie</label>
+      <input id="inputFile" class="original-config-button" type="file" accept="application/json"
+             (change)="checkFile($event.target.files)" >
+    </div>
+    <p class="uploadString">{{ uploaded }}</p>
+    <div *ngIf="uploaded != ''" class="file-output">
+      <p>Errors:</p>
+      <p *ngIf="getErrors().length == 0">No errors found!</p>
+      <mat-list class="error-list">
+        <mat-list-item *ngFor="let error of getErrors()">{{ error }}</mat-list-item>
+      </mat-list>
+    </div>
   </div>
 </div>

--- a/front-end/src/app/config/config.component.html
+++ b/front-end/src/app/config/config.component.html
@@ -7,13 +7,13 @@
              (change)="checkFile($event.target.files)" >
     </div>
     <p class="uploadString">{{ uploaded }}</p>
-    <div *ngIf="uploaded != '' && !noErrors" class="file-output-errors">
+    <div *ngIf="uploaded != '' && !noErrors()" class="file-output-errors">
       <mat-list class="error-list">
         <mat-list-item class="error-list-title">Errors</mat-list-item>
         <mat-list-item *ngFor="let error of getErrors()">{{ error }}</mat-list-item>
       </mat-list>
     </div>
-    <div *ngIf="noErrors" class="file-output-no-errors">
+    <div *ngIf="noErrors()" class="file-output-no-errors">
       <mat-list class="error-list">
         <mat-list-item class="error-list-title">Errors</mat-list-item>
         <mat-list-item>Geen errors gevonden!</mat-list-item>

--- a/front-end/src/app/config/config.component.html
+++ b/front-end/src/app/config/config.component.html
@@ -13,7 +13,7 @@
         <mat-list-item *ngFor="let error of getErrors()">{{ error }}</mat-list-item>
       </mat-list>
     </div>
-    <div *ngIf="noErrors()" class="file-output-no-errors">
+    <div *ngIf="uploaded != '' && noErrors()" class="file-output-no-errors">
       <mat-list class="error-list">
         <mat-list-item class="error-list-title">Errors</mat-list-item>
         <mat-list-item>Geen errors gevonden!</mat-list-item>

--- a/front-end/src/app/config/config.component.ts
+++ b/front-end/src/app/config/config.component.ts
@@ -11,7 +11,6 @@ export class ConfigComponent implements OnInit {
   reader: FileReader;
   uploaded = "";
   data = "";
-  newConfig = "";
   errors: string[];
   currentFile: File;
 
@@ -50,16 +49,19 @@ export class ConfigComponent implements OnInit {
    */
   checkFile(files: FileList) {
     this.currentFile = files.item(0);
-    this.uploaded = "Uploaden gelukt: " + this.currentFile.name + "!";
     this.reader.readAsText(this.currentFile, "UTF-8");
+    this.uploaded = "Uploaden gelukt: " + this.currentFile.name + "!";
   }
 
   /**
    * Use the config entered as new configuration for app.
    */
   sendConfig() {
-    this.app.sendInstruction([{ instruction: "use config", config: JSON.parse(this.data) }]);
-    this.newConfig = "Configuratie uit: " + this.currentFile.name + " wordt nu gebruikt";
+    this.app.sendInstruction([{
+      instruction: "use config",
+      config: JSON.parse(this.data),
+      file: this.currentFile.name
+    }]);
   }
 
   /**

--- a/front-end/src/app/config/config.component.ts
+++ b/front-end/src/app/config/config.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from "@angular/core";
 import { AppComponent } from "../app.component";
-import { logger } from "codelyzer/util/logger";
 
 @Component({
   selector: "app-config",
@@ -13,6 +12,9 @@ export class ConfigComponent implements OnInit {
   data: string = "";
   errors: string[];
   reader: FileReader;
+  noErrors: boolean;
+  newConfig: string;
+  currentFile: File;
 
   /**
    * Define listeners for the file reader.
@@ -31,7 +33,7 @@ export class ConfigComponent implements OnInit {
     });
     this.reader.addEventListener("error", (e) => {
       this.errors.push(e.target["result"]);
-      logger.error("log: error while reading file");
+      console.log("log: error while reading file");
       this.uploaded = "Error tijdens uploaden: " + e.target["result"];
     });
   }
@@ -43,9 +45,18 @@ export class ConfigComponent implements OnInit {
    * When file is submitted, call file reader.
    */
   checkFile(files: FileList) {
-    const file = files.item(0);
-    this.uploaded = "Uploaden gelukt: " + file.name + "!";
-    this.reader.readAsText(file, "UTF-8");
+    this.currentFile = files.item(0);
+    this.uploaded = "Uploaden gelukt: " + this.currentFile.name + "!";
+    this.reader.readAsText(this.currentFile, "UTF-8");
+    this.noErrors = this.getErrors().length === 0;
+  }
+
+  /**
+   * Use the config entered as new configuration for app.
+   */
+  sendConfig() {
+    this.app.sendInstruction([{instruction: "use config", config: this.data}])
+    this.newConfig = "Configuratie uit: " + this.currentFile.name + " wordt nu gebruikt";
   }
 
   getErrors(): string[] {

--- a/front-end/src/app/config/config.component.ts
+++ b/front-end/src/app/config/config.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from "@angular/core";
+import { AppComponent } from "../app.component";
+import {logger} from "codelyzer/util/logger";
 
 @Component({
   selector: "app-config",
@@ -7,9 +9,46 @@ import { Component, OnInit } from "@angular/core";
 })
 export class ConfigComponent implements OnInit {
 
-  constructor() { }
+  uploaded: string = "";
+  data: string = "";
+  errors: string[];
+  reader: FileReader;
+
+  /**
+   * Define listeners for the file reader.
+   * On reading file, it should check config on back-end.
+   * On error, it should add to error list and log the error.
+   */
+  constructor(private app: AppComponent) {
+    this.errors = [];
+    this.reader = new FileReader();
+    this.reader.addEventListener("load", (e) => {
+      this.data = e.target["result"];
+      this.app.sendInstruction([{ instruction: "check config", config: JSON.parse(this.data)}]);
+    });
+    this.reader.addEventListener("error", (e) => {
+      this.errors.push(e.target["result"]);
+      logger.error("log: error while reading file")
+    })
+  }
 
   ngOnInit() {
   }
 
+  /**
+   * When file is submitted, call file reader.
+   */
+  checkFile(files: FileList) {
+    const file = files.item(0);
+    this.uploaded = "Succesfully uploaded file: " + file.name + "!";
+    this.reader.readAsText(file, "UTF-8");
+  }
+
+  getErrors(): string[] {
+    const list = [];
+    for (const err of this.errors) {
+      list.push(err);
+    }
+    return list;
+  }
 }

--- a/front-end/src/app/config/config.component.ts
+++ b/front-end/src/app/config/config.component.ts
@@ -16,6 +16,7 @@ export class ConfigComponent implements OnInit {
 
   /**
    * Define listeners for the file reader.
+   * First resets the errors.
    * On reading file, it should check config on back-end.
    * On error, it should add to error list and log the error.
    */
@@ -24,12 +25,15 @@ export class ConfigComponent implements OnInit {
     this.reader = new FileReader();
     this.reader.addEventListener("load", (e) => {
       this.data = e.target["result"];
-      this.app.sendInstruction([{ instruction: "check config", config: JSON.parse(this.data)}]);
+      this.errors = [];
+      this.app.configErrorList = [];
+      this.app.sendInstruction([{ instruction: "check config", config: this.data}]);
     });
     this.reader.addEventListener("error", (e) => {
       this.errors.push(e.target["result"]);
-      logger.error("log: error while reading file")
-    })
+      logger.error("log: error while reading file");
+      this.uploaded = "Error during uploading: " + e.target["result"];
+    });
   }
 
   ngOnInit() {
@@ -46,8 +50,11 @@ export class ConfigComponent implements OnInit {
 
   getErrors(): string[] {
     const list = [];
-    for (const err of this.errors) {
+    for (const err of this.app.configErrorList) {
       list.push(err);
+    }
+    for (const err of this.errors) {
+      list.push(err)
     }
     return list;
   }

--- a/front-end/src/app/config/config.component.ts
+++ b/front-end/src/app/config/config.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 import { AppComponent } from "../app.component";
-import {logger} from "codelyzer/util/logger";
+import { logger } from "codelyzer/util/logger";
 
 @Component({
   selector: "app-config",
@@ -32,7 +32,7 @@ export class ConfigComponent implements OnInit {
     this.reader.addEventListener("error", (e) => {
       this.errors.push(e.target["result"]);
       logger.error("log: error while reading file");
-      this.uploaded = "Error during uploading: " + e.target["result"];
+      this.uploaded = "Error tijdens uploaden: " + e.target["result"];
     });
   }
 
@@ -44,7 +44,7 @@ export class ConfigComponent implements OnInit {
    */
   checkFile(files: FileList) {
     const file = files.item(0);
-    this.uploaded = "Succesfully uploaded file: " + file.name + "!";
+    this.uploaded = "Uploaden gelukt: " + file.name + "!";
     this.reader.readAsText(file, "UTF-8");
   }
 

--- a/front-end/src/app/config/config.component.ts
+++ b/front-end/src/app/config/config.component.ts
@@ -8,15 +8,15 @@ import { AppComponent } from "../app.component";
 })
 export class ConfigComponent implements OnInit {
 
-  uploaded: string = "";
-  data: string = "";
   reader: FileReader;
-  newConfig: string = "";
+  uploaded = "";
+  data = "";
+  newConfig = "";
   errors: string[];
   currentFile: File;
 
   /**
-   * Define listeners for the file reader.
+   * Define listeners for the file reader, which is used in the file reading button.
    * First resets the errors.
    * On reading file, it should check config on back-end.
    * On error, it should add to error list and log the error.
@@ -24,16 +24,21 @@ export class ConfigComponent implements OnInit {
   constructor(private app: AppComponent) {
     this.errors = [];
     this.reader = new FileReader();
+    const res = "result";
     this.reader.addEventListener("load", (e) => {
-      this.data = e.target["result"];
+      this.data = e.target[res];
       this.errors = [];
       this.app.configErrorList = [];
-      this.app.sendInstruction([{ instruction: "check config", config: this.data}]);
+      this.app.sendInstruction(
+        [{
+          instruction: "check config",
+          config: JSON.parse(this.data)
+        }]);
     });
     this.reader.addEventListener("error", (e) => {
-      this.errors.push(e.target["result"]);
+      this.errors.push(e.target[res]);
       console.log("log: error while reading file");
-      this.uploaded = "Error tijdens uploaden: " + e.target["result"];
+      this.uploaded = "Error tijdens uploaden: " + e.target[res];
     });
   }
 
@@ -53,11 +58,13 @@ export class ConfigComponent implements OnInit {
    * Use the config entered as new configuration for app.
    */
   sendConfig() {
-    this.app.sendInstruction([{instruction: "use config", config: this.data}]);
+    this.app.sendInstruction([{ instruction: "use config", config: JSON.parse(this.data) }]);
     this.newConfig = "Configuratie uit: " + this.currentFile.name + " wordt nu gebruikt";
   }
 
-  // All JSON errors will be shown per one - json unmarshal
+  /**
+   * All JSON errors will be shown per one - json unmarshal
+   */
   getErrors(): string[] {
     const list = [];
     for (const err of this.app.configErrorList) {
@@ -70,6 +77,6 @@ export class ConfigComponent implements OnInit {
   }
 
   noErrors(): boolean {
-    return this.errors.length == 0 && this.app.configErrorList.length == 0;
+    return this.errors.length === 0 && this.app.configErrorList.length === 0;
   }
 }

--- a/front-end/src/app/config/config.component.ts
+++ b/front-end/src/app/config/config.component.ts
@@ -57,6 +57,7 @@ export class ConfigComponent implements OnInit {
     this.newConfig = "Configuratie uit: " + this.currentFile.name + " wordt nu gebruikt";
   }
 
+  // All JSON errors will be shown per one - json unmarshal
   getErrors(): string[] {
     const list = [];
     for (const err of this.app.configErrorList) {

--- a/front-end/src/app/config/config.component.ts
+++ b/front-end/src/app/config/config.component.ts
@@ -10,10 +10,9 @@ export class ConfigComponent implements OnInit {
 
   uploaded: string = "";
   data: string = "";
-  errors: string[];
   reader: FileReader;
-  noErrors: boolean;
-  newConfig: string;
+  newConfig: string = "";
+  errors: string[];
   currentFile: File;
 
   /**
@@ -48,14 +47,13 @@ export class ConfigComponent implements OnInit {
     this.currentFile = files.item(0);
     this.uploaded = "Uploaden gelukt: " + this.currentFile.name + "!";
     this.reader.readAsText(this.currentFile, "UTF-8");
-    this.noErrors = this.getErrors().length === 0;
   }
 
   /**
    * Use the config entered as new configuration for app.
    */
   sendConfig() {
-    this.app.sendInstruction([{instruction: "use config", config: this.data}])
+    this.app.sendInstruction([{instruction: "use config", config: this.data}]);
     this.newConfig = "Configuratie uit: " + this.currentFile.name + " wordt nu gebruikt";
   }
 
@@ -68,5 +66,9 @@ export class ConfigComponent implements OnInit {
       list.push(err)
     }
     return list;
+  }
+
+  noErrors(): boolean {
+    return this.errors.length == 0 && this.app.configErrorList.length == 0;
   }
 }

--- a/front-end/src/assets/css/main.css
+++ b/front-end/src/assets/css/main.css
@@ -79,16 +79,23 @@ body { /*body of the index.html*/
 
 
 /*Small screens should have small margin*/
-@media only screen and (max-width: 500px) {
+@media only screen and (max-width: 800px) {
+  @media only screen and (min-width: 650px) {
+    .left {
+      margin: 0 5px 0 0;
+    }
+  }
   .home-box {
-    margin: 5px;
+    margin: 0;
+  }
+  .main-content {
+    padding: 0;
+  }
+  .home-box .contents {
+    padding: 0;
   }
 }
-@media only screen and (min-width: 650px) and (max-width: 700px) {
-  .home-box {
-    margin: 5px;
-  }
-}
+
 /*Define grid home page for large screens*/
 @media only screen and (min-width: 650px) {
   .timer-box {grid-area: timer}


### PR DESCRIPTION
### Issue
Closes GH-47
This was branched of closes GH-39 due to menu already implemented there

## Contents
- adds page for entering config on front-end
- shows errors in box
    1. JSON errors shown first, one by one - because of golang json, can write manual key checker to show all at once GH-76
    2. Errors shown on incorrect formats/wrong strings shown second
    3. errors checking for matching id's etc shown third
- if there are no errors, user can select to use the entered config for the app


## TODO
- [x] testing the handler methods of the config don't work yet due to the loading of json from file and then sending it in json message
- [x] check that reset still works with correct config after loading

## Screen
big screen errors in config
![image](https://user-images.githubusercontent.com/23522361/71532201-95e17980-28f2-11ea-9727-0d816bfc57c6.png)

small screen no errors
![image](https://user-images.githubusercontent.com/23522361/71532221-a560c280-28f2-11ea-8568-19722df11bd0.png)
