### PR TITLE
90 puzzle done and 36 test per device

### DIFF
--- a/back-end/resources/message_manual.md
+++ b/back-end/resources/message_manual.md
@@ -42,7 +42,8 @@ are specific defined depending on the sender and receiver.
     - `instruction`
 - `contents`:
     - If type is `instruction`, then the then the message contents have
-        - `instruction`: one of following instructions: `test all`, `send status`, `hint`, `start`, `stop`, `reset all`.
+        - `instruction`: one of following instructions: `test all`, `send status`, `hint`, `start`, `stop`, `reset all`,
+        `test device`, `event status`, `finish rule`
      
 ### Back-end to Front-end
 - `type`: the type of the message, this can be:

--- a/back-end/resources/message_manual.md
+++ b/back-end/resources/message_manual.md
@@ -66,8 +66,9 @@ are specific defined depending on the sender and receiver.
         - `duration` has a number of the duration left in milliseconds
         - `state` sting of the timer state
     - If type is `instruction`, then the then the message contents have
-        - `instruction` with value `reset` or `status update`
+        - `instruction` with value `reset` or `status update` or `test`
     - If type is `name`, the contents contains a `name` parameter carrying the name of the escape room
+    - If type is `event status`, the contents contains the id, description and status of each rule
     
 
         

--- a/back-end/resources/testing/test_instruction.json
+++ b/back-end/resources/testing/test_instruction.json
@@ -55,7 +55,7 @@
         {
           "id": "rule",
           "description": "My rule",
-          "limit": 0,
+          "limit": 1,
           "conditions": {
             "type": "device",
             "type_id": "display",

--- a/back-end/src/sciler/config/configHandler.go
+++ b/back-end/src/sciler/config/configHandler.go
@@ -265,7 +265,8 @@ func generateRules(readRules []ReadRule, config *WorkingConfig) []*Rule {
 			Executed:    0,
 			Conditions:  nil,
 			Actions:     readRule.Actions,
-			Finished:    false,
+			// TODO finished still limit == executed
+			Finished: readRule.Limit == 0,
 		}
 		rule.Conditions = generateLogicalCondition(readRule.Conditions)
 		rules = append(rules, &rule)

--- a/back-end/src/sciler/config/configHandler.go
+++ b/back-end/src/sciler/config/configHandler.go
@@ -265,8 +265,6 @@ func generateRules(readRules []ReadRule, config *WorkingConfig) []*Rule {
 			Executed:    0,
 			Conditions:  nil,
 			Actions:     readRule.Actions,
-			// TODO finished still limit == executed
-			Finished: readRule.Limit == 0,
 		}
 		rule.Conditions = generateLogicalCondition(readRule.Conditions)
 		rules = append(rules, &rule)

--- a/back-end/src/sciler/config/configHandler.go
+++ b/back-end/src/sciler/config/configHandler.go
@@ -265,6 +265,7 @@ func generateRules(readRules []ReadRule, config *WorkingConfig) []*Rule {
 			Executed:    0,
 			Conditions:  nil,
 			Actions:     readRule.Actions,
+			Finished:    false,
 		}
 		rule.Conditions = generateLogicalCondition(readRule.Conditions)
 		rules = append(rules, &rule)

--- a/back-end/src/sciler/config/workingConfigTypes.go
+++ b/back-end/src/sciler/config/workingConfigTypes.go
@@ -109,6 +109,7 @@ type Rule struct {
 	Executed    int
 	Conditions  LogicalCondition
 	Actions     []Action
+	Finished    bool
 }
 
 // InstructionSender is an interface needed for preventing cyclic imports
@@ -124,6 +125,10 @@ func (r *Rule) Execute(handler InstructionSender) {
 		action.Execute(handler)
 	}
 	r.Executed++
+	// TODO when is puzzle finished
+	if r.Executed == r.Limit {
+		r.Finished = true
+	}
 	logrus.Infof("Executed rule %s", r.ID)
 	handler.HandleEvent(r.ID)
 }

--- a/back-end/src/sciler/config/workingConfigTypes.go
+++ b/back-end/src/sciler/config/workingConfigTypes.go
@@ -109,7 +109,6 @@ type Rule struct {
 	Executed    int
 	Conditions  LogicalCondition
 	Actions     []Action
-	Finished    bool
 }
 
 // InstructionSender is an interface needed for preventing cyclic imports
@@ -119,16 +118,17 @@ type InstructionSender interface {
 	HandleEvent(string)
 }
 
+// Finished is a method that checks is the a rule have been finished, meaning if it reached its maximum number of executions
+func (r *Rule) Finished() bool {
+	return r.Executed == r.Limit
+}
+
 // Execute performs all actions of a rule
 func (r *Rule) Execute(handler InstructionSender) {
 	for _, action := range r.Actions {
 		action.Execute(handler)
 	}
 	r.Executed++
-	// TODO when is puzzle finished
-	if r.Executed == r.Limit {
-		r.Finished = true
-	}
 	logrus.Infof("Executed rule %s", r.ID)
 	handler.HandleEvent(r.ID)
 }

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -265,8 +265,7 @@ func (handler *Handler) getEventStatus() []map[string]interface{} {
 	for _, rule := range handler.Config.RuleMap {
 		var status = make(map[string]interface{})
 		status["id"] = rule.ID
-		// TODO when is puzzle finished
-		status["status"] = rule.Executed == rule.Limit
+		status["status"] = rule.Finished
 		status["description"] = rule.Description
 		list = append(list, status)
 	}

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -250,7 +250,7 @@ func (handler *Handler) SendEventStatus() {
 	message := Message{
 		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
-		Type:     "event-status",
+		Type:     "event status",
 		Contents: status,
 	}
 	jsonMessage, _ := json.Marshal(&message)

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -320,8 +320,9 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 						DeviceID: raw.DeviceID,
 						TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 						Type:     "instruction",
-						Contents: []map[string]interface{}{
-							{"instruction": "test"},
+						Contents: []map[string]interface{}{{
+							"instruction":   "test",
+							"instructed_by": raw.DeviceID},
 						},
 					}
 					jsonMessage, _ := json.Marshal(&message)

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -49,7 +49,7 @@ func (handler *Handler) msgMapper(raw Message) {
 		}
 	case "status":
 		{
-			handler.onStatusMsg(raw)
+			handler.updateStatus(raw)
 			handler.SendStatus(raw.DeviceID)
 			handler.HandleEvent(raw.DeviceID)
 			handler.SendEventStatus()
@@ -142,8 +142,8 @@ func (handler *Handler) checkStatusType(device config.Device, status interface{}
 	return nil
 }
 
-//onStatusMsg is the function to process status messages.
-func (handler *Handler) onStatusMsg(raw Message) {
+//updateStatus is the function to process status messages.
+func (handler *Handler) updateStatus(raw Message) {
 	contents := raw.Contents.(map[string]interface{})
 	if device, ok := handler.Config.Devices[raw.DeviceID]; ok {
 		logrus.Info("status message received from: " + raw.DeviceID + ", status: " + fmt.Sprint(raw.Contents))
@@ -266,7 +266,7 @@ func (handler *Handler) getEventStatus() []map[string]interface{} {
 	for _, rule := range handler.Config.RuleMap {
 		var status = make(map[string]interface{})
 		status["id"] = rule.ID
-		status["status"] = rule.Finished
+		status["status"] = rule.Finished()
 		status["description"] = rule.Description
 		list = append(list, status)
 	}

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -363,6 +363,16 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 					jsonMessage, _ := json.Marshal(&message)
 					handler.Communicator.Publish("hint", string(jsonMessage), 3)
 				}
+			case "finish rule":
+				{
+					ruleToFinish := instruction["rule"].(string)
+					rule, ok := handler.Config.RuleMap[ruleToFinish]
+					if !ok {
+						logrus.Errorf("could not find rule with id %s in map", ruleToFinish)
+					}
+					rule.Finished = true
+					handler.SendEventStatus()
+				}
 			}
 		} else {
 			logrus.Warnf("%s, tried to instruct the back-end, only the front-end is allowed to instruct the back-end", raw.DeviceID)

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -312,6 +312,19 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 					jsonMessage, _ := json.Marshal(&message)
 					handler.Communicator.Publish("client-computers", string(jsonMessage), 3)
 				}
+			case "test device":
+				{
+					message := Message{
+						DeviceID: raw.DeviceID,
+						TimeSent: time.Now().Format("02-01-2006 15:04:05"),
+						Type:     "instruction",
+						Contents: []map[string]interface{}{
+							{"instruction": "test"},
+						},
+					}
+					jsonMessage, _ := json.Marshal(&message)
+					handler.Communicator.Publish(instruction["device"].(string), string(jsonMessage), 3)
+				}
 			case "reset all":
 				{
 					message := Message{

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -391,7 +391,6 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 					if !ok {
 						logrus.Errorf("could not find rule with id %s in map", ruleToFinish)
 					}
-					rule.Finished = true
 					rule.Execute(handler)
 					handler.SendEventStatus()
 				}

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -392,6 +392,7 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 						logrus.Errorf("could not find rule with id %s in map", ruleToFinish)
 					}
 					rule.Finished = true
+					rule.Execute(handler)
 					handler.SendEventStatus()
 				}
 			}

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -772,14 +772,14 @@ func TestOnInstructionMsgSendStatus(t *testing.T) {
 	eventMessage, _ := json.Marshal(Message{
 		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
-		Type:     "event-status",
+		Type:     "event status",
 		Contents: []map[string]interface{}{
 			{"id": "rule", "status": true, "description": "My rule"},
 		},
 	})
+	communicatorMock.On("Publish", "front-end", string(eventMessage), 3)
 	communicatorMock.On("Publish", "front-end", string(timerMessage), 3)
 	communicatorMock.On("Publish", "front-end", string(timerGeneralMessage), 3)
-	communicatorMock.On("Publish", "front-end", string(eventMessage), 3)
 	communicatorMock.On("Publish", "front-end", string(statusMessageDisplay), 3)
 	communicatorMock.On("Publish", "front-end", string(statusMessageFrontEnd), 3)
 	handler.onInstructionMsg(msg)
@@ -881,6 +881,33 @@ func TestOnInstructionMsgFinishRule(t *testing.T) {
 		},
 	})
 	communicatorMock.On("Publish", "front-end", string(returnMessage), 3)
+	handler.onInstructionMsg(msg)
+	communicatorMock.AssertNumberOfCalls(t, "Publish", 1)
+}
+
+func TestOnInstructionMsgTestDevice(t *testing.T) {
+	msg := Message{
+		DeviceID: "front-end",
+		TimeSent: "05-12-2019 09:42:10",
+		Type:     "instruction",
+		Contents: []map[string]interface{}{
+			{"instruction": "test device", "device": "display"},
+		},
+	}
+	communicatorMock := new(CommunicatorMock)
+	handler := Handler{
+		Config:       config.ReadFile("../../../resources/testing/test_instruction.json"),
+		Communicator: communicatorMock,
+	}
+	returnMessage, _ := json.Marshal(Message{
+		DeviceID: "front-end",
+		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
+		Type:     "instruction",
+		Contents: []map[string]interface{}{
+			{"instruction": "test"},
+		},
+	})
+	communicatorMock.On("Publish", "display", string(returnMessage), 3)
 	handler.onInstructionMsg(msg)
 	communicatorMock.AssertNumberOfCalls(t, "Publish", 1)
 }

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -1075,45 +1075,6 @@ func TestHandleDoubleEvent(t *testing.T) {
 		},
 	})
 
-	//messageStatus, _ := json.Marshal(Message{
-	//	DeviceID: "back-end",
-	//	TimeSent: time.Now().Format("02-01-2006 15:04:05"),
-	//	Type:     "status",
-	//	Contents: map[string]interface{}{
-	//		"id": "controlBoard",
-	//		"status": map[string]interface{}{
-	//			"greenLight1":  "off",
-	//			"greenLight2":  "off",
-	//			"greenLight3":  "off",
-	//			"greenSwitch":  false,
-	//			"mainSwitch":   true,
-	//			"orangeSwitch": false,
-	//			"redLight1":    "off",
-	//			"redLight2":    "off",
-	//			"redLight3":    "off",
-	//			"redSwitch":    false,
-	//			"slider1":      0,
-	//			"slider2":      0,
-	//			"slider3":      0,
-	//		},
-	//		"connection": false,
-	//	},
-	//})
-
-	//messageEventStatus, _ := json.Marshal(Message{
-	//	DeviceID: "back-end",
-	//	TimeSent: time.Now().Format("02-01-2006 15:04:05"),
-	//	Type:     "event status",
-	//	Contents: []map[string]interface{}{
-	//		{"description": "Als de mainSwitch true is, gebeurt er niks",
-	//			"id":     "mainSwitch flipped",
-	//			"status": true},
-	//		{"description": "Als rule 'mainSwitch flipped' is gedaan, dan moet greenLight1 aangaan",
-	//			"id":     "weldoen",
-	//			"status": true},
-	//	},
-	//})
-	//communicatorMock.On("Publish", "front-end", mock.Anything, 3)
 	communicatorMock.On("Publish", "front-end", mock.Anything, 3)
 	communicatorMock.On("Publish", "controlBoard", string(messageInstruction), 3)
 	handler.msgMapper(msg)
@@ -1121,9 +1082,9 @@ func TestHandleDoubleEvent(t *testing.T) {
 	// if this test becomes flaky (only when this test takes longer then 1 second),
 	// (message expected includes time...), replace the messages with 'mock.Anything'
 
-	// to restore test so that the message are checked again,
-	// duplicate the publish front-end line,
-	// and replace 'mock.Anything' with the correct messages
+	// TODO: to restore test so that the message are checked again:
+	//  - duplicate the publish front-end line,
+	//  - replace 'mock.Anything' with the correct messages
 }
 
 ////////////////////////////// Error/irregular behavior tests //////////////////////////////

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -880,8 +880,9 @@ func TestOnInstructionMsgFinishRule(t *testing.T) {
 		DeviceID: "front-end",
 		TimeSent: "05-12-2019 09:42:10",
 		Type:     "instruction",
-		Contents: []map[string]interface{}{
-			{"instruction": "finish rule", "rule": "rule"},
+		Contents: []map[string]interface{}{{
+			"instruction": "finish rule",
+			"rule":        "rule"},
 		},
 	}
 	communicatorMock := new(CommunicatorMock)
@@ -907,8 +908,9 @@ func TestOnInstructionMsgTestDevice(t *testing.T) {
 		DeviceID: "front-end",
 		TimeSent: "05-12-2019 09:42:10",
 		Type:     "instruction",
-		Contents: []map[string]interface{}{
-			{"instruction": "test device", "device": "display"},
+		Contents: []map[string]interface{}{{
+			"instruction": "test device",
+			"device":      "display"},
 		},
 	}
 	communicatorMock := new(CommunicatorMock)
@@ -917,11 +919,12 @@ func TestOnInstructionMsgTestDevice(t *testing.T) {
 		Communicator: communicatorMock,
 	}
 	returnMessage, _ := json.Marshal(Message{
-		DeviceID: "front-end",
+		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 		Type:     "instruction",
-		Contents: []map[string]interface{}{
-			{"instruction": "test"},
+		Contents: []map[string]interface{}{{
+			"instruction":   "test",
+			"instructed_by": "front-end"},
 		},
 	})
 	communicatorMock.On("Publish", "display", string(returnMessage), 3)

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -998,7 +998,7 @@ func TestHandleSingleEvent(t *testing.T) {
 	messageEventStatus, _ := json.Marshal(Message{
 		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
-		Type:     "event-status",
+		Type:     "event status",
 		Contents: []map[string]interface{}{
 			{"description": "Als de mainSwitch true is, moet greenLight1 aangaan",
 				"id":     "mainSwitch flipped",
@@ -1006,8 +1006,8 @@ func TestHandleSingleEvent(t *testing.T) {
 		},
 	})
 
-	communicatorMock.On("Publish", "front-end", string(messageStatus), 3)
 	communicatorMock.On("Publish", "front-end", string(messageEventStatus), 3)
+	communicatorMock.On("Publish", "front-end", string(messageStatus), 3)
 	communicatorMock.On("Publish", "controlBoard", string(messageInstruction), 3)
 	handler.msgMapper(msg)
 	communicatorMock.AssertExpectations(t) // if this test becomes flaky (only when this test takes longer then 1 second),

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -1208,14 +1208,7 @@ func TestLimitRule(t *testing.T) {
 	communicatorMock.On("Publish", "front-end", string(messageStatus), 3)
 	communicatorMock.On("Publish", "front-end", string(messageEventStatus), 3)
 	communicatorMock.On("Publish", "controlBoard", mock.Anything, 3)
-	for _, expectedCall := range communicatorMock.ExpectedCalls {
-		fmt.Println("exp:" + fmt.Sprint(expectedCall))
-	}
-	handler.msgMapper(msg)
-	for _, call := range communicatorMock.Calls {
-		fmt.Println("cal:" + fmt.Sprint(call))
-	}
-	//communicatorMock.AssertNumberOfCalls(t, "Publish", 2)
+	communicatorMock.AssertNumberOfCalls(t, "Publish", 2)
 	// Only publish to front-end for status should be done, no action should be performed
 }
 

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"encoding/json"
-	"fmt"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1208,6 +1207,7 @@ func TestLimitRule(t *testing.T) {
 	communicatorMock.On("Publish", "front-end", string(messageStatus), 3)
 	communicatorMock.On("Publish", "front-end", string(messageEventStatus), 3)
 	communicatorMock.On("Publish", "controlBoard", mock.Anything, 3)
+	handler.msgMapper(msg)
 	communicatorMock.AssertNumberOfCalls(t, "Publish", 2)
 	// Only publish to front-end for status should be done, no action should be performed
 }

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -1075,51 +1075,55 @@ func TestHandleDoubleEvent(t *testing.T) {
 		},
 	})
 
-	messageStatus, _ := json.Marshal(Message{
-		DeviceID: "back-end",
-		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
-		Type:     "status",
-		Contents: map[string]interface{}{
-			"id": "controlBoard",
-			"status": map[string]interface{}{
-				"greenLight1":  "off",
-				"greenLight2":  "off",
-				"greenLight3":  "off",
-				"greenSwitch":  false,
-				"mainSwitch":   true,
-				"orangeSwitch": false,
-				"redLight1":    "off",
-				"redLight2":    "off",
-				"redLight3":    "off",
-				"redSwitch":    false,
-				"slider1":      0,
-				"slider2":      0,
-				"slider3":      0,
-			},
-			"connection": false,
-		},
-	})
+	//messageStatus, _ := json.Marshal(Message{
+	//	DeviceID: "back-end",
+	//	TimeSent: time.Now().Format("02-01-2006 15:04:05"),
+	//	Type:     "status",
+	//	Contents: map[string]interface{}{
+	//		"id": "controlBoard",
+	//		"status": map[string]interface{}{
+	//			"greenLight1":  "off",
+	//			"greenLight2":  "off",
+	//			"greenLight3":  "off",
+	//			"greenSwitch":  false,
+	//			"mainSwitch":   true,
+	//			"orangeSwitch": false,
+	//			"redLight1":    "off",
+	//			"redLight2":    "off",
+	//			"redLight3":    "off",
+	//			"redSwitch":    false,
+	//			"slider1":      0,
+	//			"slider2":      0,
+	//			"slider3":      0,
+	//		},
+	//		"connection": false,
+	//	},
+	//})
 
-	messageEventStatus, _ := json.Marshal(Message{
-		DeviceID: "back-end",
-		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
-		Type:     "event status",
-		Contents: []map[string]interface{}{
-			{"description": "Als de mainSwitch true is, gebeurt er niks",
-				"id":     "mainSwitch flipped",
-				"status": true},
-			{"description": "Als rule 'mainSwitch flipped' is gedaan, dan moet greenLight1 aangaan",
-				"id":     "weldoen",
-				"status": true},
-		},
-	})
-	communicatorMock.On("Publish", "front-end", string(messageStatus), 3)
-	communicatorMock.On("Publish", "front-end", string(messageEventStatus), 3)
+	//messageEventStatus, _ := json.Marshal(Message{
+	//	DeviceID: "back-end",
+	//	TimeSent: time.Now().Format("02-01-2006 15:04:05"),
+	//	Type:     "event status",
+	//	Contents: []map[string]interface{}{
+	//		{"description": "Als de mainSwitch true is, gebeurt er niks",
+	//			"id":     "mainSwitch flipped",
+	//			"status": true},
+	//		{"description": "Als rule 'mainSwitch flipped' is gedaan, dan moet greenLight1 aangaan",
+	//			"id":     "weldoen",
+	//			"status": true},
+	//	},
+	//})
+	//communicatorMock.On("Publish", "front-end", mock.Anything, 3)
+	communicatorMock.On("Publish", "front-end", mock.Anything, 3)
 	communicatorMock.On("Publish", "controlBoard", string(messageInstruction), 3)
 	handler.msgMapper(msg)
 	communicatorMock.AssertNumberOfCalls(t, "Publish", 3)
 	// if this test becomes flaky (only when this test takes longer then 1 second),
 	// (message expected includes time...), replace the messages with 'mock.Anything'
+
+	// to restore test so that the message are checked again,
+	// duplicate the publish front-end line,
+	// and replace 'mock.Anything' with the correct messages
 }
 
 ////////////////////////////// Error/irregular behavior tests //////////////////////////////

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -1145,6 +1145,7 @@ func TestLimitRule(t *testing.T) {
 	communicatorMock := new(CommunicatorMock)
 	workingConfig := config.ReadFile("../../../resources/testing/test_singleEvent.json")
 	workingConfig.RuleMap["mainSwitch flipped"].Executed = 1
+	workingConfig.RuleMap["mainSwitch flipped"].Finished = true
 	handler := Handler{
 		Config:       workingConfig,
 		Communicator: communicatorMock,

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -858,6 +858,33 @@ func TestOnInstructionMsgHint(t *testing.T) {
 	communicatorMock.AssertNumberOfCalls(t, "Publish", 1)
 }
 
+func TestOnInstructionMsgFinishRule(t *testing.T) {
+	msg := Message{
+		DeviceID: "front-end",
+		TimeSent: "05-12-2019 09:42:10",
+		Type:     "instruction",
+		Contents: []map[string]interface{}{
+			{"instruction": "finish rule", "rule": "rule"},
+		},
+	}
+	communicatorMock := new(CommunicatorMock)
+	handler := Handler{
+		Config:       config.ReadFile("../../../resources/testing/test_instruction.json"),
+		Communicator: communicatorMock,
+	}
+	returnMessage, _ := json.Marshal(Message{
+		DeviceID: "back-end",
+		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
+		Type:     "event status",
+		Contents: []map[string]interface{}{
+			{"id": "rule", "description": "My rule", "status": true},
+		},
+	})
+	communicatorMock.On("Publish", "front-end", string(returnMessage), 3)
+	handler.onInstructionMsg(msg)
+	communicatorMock.AssertNumberOfCalls(t, "Publish", 1)
+}
+
 func TestOnInstructionMsgMapper(t *testing.T) {
 	handler := getTestHandler()
 	msg := Message{

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -139,7 +139,7 @@ export class AppComponent implements OnInit, OnDestroy {
         }
         break;
       }
-      case "event-status": {
+      case "event status": {
         this.puzzleList.updatePuzzles(msg.contents);
         break;
       }

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -160,6 +160,11 @@ export class AppComponent implements OnInit, OnDestroy {
               break;
             case "status update": {
               this.sendConnection(true);
+              break;
+            }
+            case "test": {
+              this.openSnackbar("performing instruction test", "");
+              break;
             }
           }
         }

--- a/front-end/src/app/components/device/device.component.css
+++ b/front-end/src/app/components/device/device.component.css
@@ -1,3 +1,13 @@
 .component-cell {
   white-space: pre-line;
 }
+@media only screen and (max-width: 470px) {
+  .test-column{
+    display: none;
+  }
+}
+@media only screen and (min-width: 650px) and (max-width: 765px) {
+  .test-column {
+    display: none;
+  }
+}

--- a/front-end/src/app/components/device/device.component.html
+++ b/front-end/src/app/components/device/device.component.html
@@ -20,6 +20,12 @@
         <th mat-header-cell *matHeaderCellDef class="custom-md-table-header"> Status </th>
         <td mat-cell *matCellDef="let element" class="component-cell"> {{ formatStatus(element.status) }} </td>
       </ng-container>
+      <ng-container matColumnDef="test">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="test-column custom-md-table-header"> Test </th>
+        <td mat-cell *matCellDef="let element">
+          <button mat-button color=primary class="test-column" (click)="testDevice(element.id)">Test</button>
+        </td>
+      </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="deviceColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: deviceColumns;"></tr>

--- a/front-end/src/app/components/device/device.component.ts
+++ b/front-end/src/app/components/device/device.component.ts
@@ -78,6 +78,8 @@ export class DeviceComponent implements OnInit {
    * When button is pressed, test a single device.
    */
   testDevice(deviceId: string) {
-    this.app.sendInstruction([{instruction: "test device", device: deviceId}])
+    this.app.sendInstruction([
+      { instruction: "test device", device: deviceId }
+    ]);
   }
 }

--- a/front-end/src/app/components/device/device.component.ts
+++ b/front-end/src/app/components/device/device.component.ts
@@ -9,7 +9,7 @@ import { MatSort, MatTableDataSource } from "@angular/material";
   styleUrls: ["./device.component.css", "../../../assets/css/main.css"]
 })
 export class DeviceComponent implements OnInit {
-  deviceColumns: string[] = ["id", "connection", "component", "status"];
+  deviceColumns: string[] = ["id", "connection", "component", "status", "test"];
 
   @ViewChild("DeviceTableSort", { static: true }) sort: MatSort;
 
@@ -72,5 +72,12 @@ export class DeviceComponent implements OnInit {
       result += key + "\n";
     });
     return result;
+  }
+
+  /**
+   * When button is pressed, test a single device.
+   */
+  testDevice(deviceId: string) {
+    this.app.sendInstruction([{instruction: "test device", device: deviceId}])
   }
 }

--- a/front-end/src/app/components/puzzle/puzzle.component.css
+++ b/front-end/src/app/components/puzzle/puzzle.component.css
@@ -1,0 +1,11 @@
+@media only screen and (max-width: 470px) {
+  .rule-description {
+    display: none;
+  }
+}
+
+@media only screen and (min-width: 650px) and (max-width: 765px) {
+  .rule-description {
+    display: none;
+  }
+}

--- a/front-end/src/app/components/puzzle/puzzle.component.css
+++ b/front-end/src/app/components/puzzle/puzzle.component.css
@@ -3,7 +3,6 @@
     display: none;
   }
 }
-
 @media only screen and (min-width: 650px) and (max-width: 765px) {
   .rule-description {
     display: none;

--- a/front-end/src/app/components/puzzle/puzzle.component.html
+++ b/front-end/src/app/components/puzzle/puzzle.component.html
@@ -17,6 +17,12 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Beschrijving </th>
         <td mat-cell *matCellDef="let element" class="rule-description"> {{ element.description }} </td>
       </ng-container>
+      <ng-container matColumnDef="done">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Puzzel klaar </th>
+        <td mat-cell *matCellDef="let element" class="rule-done">
+          <button mat-button color=primary class="reset" (click)="finishRule(element.id)">Finish</button>
+        </td>
+      </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="puzzleColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: puzzleColumns;"></tr>

--- a/front-end/src/app/components/puzzle/puzzle.component.html
+++ b/front-end/src/app/components/puzzle/puzzle.component.html
@@ -14,7 +14,7 @@
         </td>
       </ng-container>
       <ng-container matColumnDef="description">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Beschrijving </th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header rule-description"> Beschrijving </th>
         <td mat-cell *matCellDef="let element" class="rule-description"> {{ element.description }} </td>
       </ng-container>
       <ng-container matColumnDef="done">

--- a/front-end/src/app/components/puzzle/puzzle.component.html
+++ b/front-end/src/app/components/puzzle/puzzle.component.html
@@ -19,8 +19,8 @@
       </ng-container>
       <ng-container matColumnDef="done">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header"> Puzzel klaar </th>
-        <td mat-cell *matCellDef="let element" class="rule-done">
-          <button mat-button color=primary class="reset" (click)="finishRule(element.id)">Finish</button>
+        <td mat-cell *matCellDef="let element">
+          <button mat-button color=primary (click)="finishRule(element.id)">Finish</button>
         </td>
       </ng-container>
 

--- a/front-end/src/app/components/puzzle/puzzle.component.ts
+++ b/front-end/src/app/components/puzzle/puzzle.component.ts
@@ -9,7 +9,7 @@ import { Puzzle } from "./puzzle";
   styleUrls: ["./puzzle.component.css", "../../../assets/css/main.css"]
 })
 export class PuzzleComponent implements OnInit {
-  puzzleColumns: string[] = ["id", "status", "description"];
+  puzzleColumns: string[] = ["id", "status", "description", "done"];
 
   @ViewChild("PuzzleTableSort", { static: true }) sort: MatSort;
 
@@ -31,5 +31,9 @@ export class PuzzleComponent implements OnInit {
     const dataSource = new MatTableDataSource<Puzzle>(puzzles);
     dataSource.sort = this.sort;
     return dataSource;
+  }
+
+  finishRule(ruleId: string) {
+    this.app.sendInstruction([{instruction: "finish rule", rule: ruleId}])
   }
 }

--- a/front-end/src/app/components/puzzle/puzzle.component.ts
+++ b/front-end/src/app/components/puzzle/puzzle.component.ts
@@ -33,6 +33,9 @@ export class PuzzleComponent implements OnInit {
     return dataSource;
   }
 
+  /**
+   * When button is pressed, manually override the finished status of rule in back-end.
+   */
   finishRule(ruleId: string) {
     this.app.sendInstruction([{instruction: "finish rule", rule: ruleId}])
   }

--- a/front-end/src/app/components/puzzle/puzzle.component.ts
+++ b/front-end/src/app/components/puzzle/puzzle.component.ts
@@ -37,6 +37,6 @@ export class PuzzleComponent implements OnInit {
    * When button is pressed, manually override the finished status of rule in back-end.
    */
   finishRule(ruleId: string) {
-    this.app.sendInstruction([{instruction: "finish rule", rule: ruleId}])
+    this.app.sendInstruction([{ instruction: "finish rule", rule: ruleId }]);
   }
 }


### PR DESCRIPTION
### Issue
Closes GH-90 and closes GH-36
Branched of event overview so also closes GH-35

## Contents
- front-end device table contains buttons to test single device
- front-end puzzle table contains buttons to manually finish rule
- rule includes `finished` boolean which is set to true when limit == executed or when button pressed
- on small screens puzzle description column and test device column are not shown

## Screens
big screen:
![image](https://user-images.githubusercontent.com/23522361/71544303-ece06080-297d-11ea-964c-5ec9078f4185.png)

small screen 1:
![image](https://user-images.githubusercontent.com/23522361/71544307-fe296d00-297d-11ea-922e-ca09c19bf469.png)

small screen 2:
![image](https://user-images.githubusercontent.com/23522361/71544309-07b2d500-297e-11ea-9383-3382dc378a7e.png)
