### PR TITLE
80 included instructed by parameter on instruction messages

### DIFF
--- a/back-end/resources/message_manual.md
+++ b/back-end/resources/message_manual.md
@@ -18,6 +18,7 @@ are specific defined depending on the sender and receiver.
         - `instruction`: one of the instructions specified for this device or 
         component or one of following instructions: `test`, `status update`, `reset`
         - `value`: this is the value (argument) for the instruction (optional)
+        - `instructed_by`: this is the id of the device which originally send this instruction (usually front-end)
         - `component_id`: this will be the id of a component in a timer or device, 
                 (optional)
    
@@ -32,7 +33,7 @@ are specific defined depending on the sender and receiver.
     a format defined in the configurations of the device. e.g. `{redSwitch: true, redSlider: 40, redLed: "aan"}`
     - If type is `confirmation`,  then the message contents has te following:
         - `completed` is a boolean.
-        - `instructed` is the original instruction message for the device
+        - `instructed` is the original instruction message for the device, including the `instructed_by` tag
     - If type is `connection`, then the message contents has te following:
         - `connection` is a boolean defining the connection status of the device.
         
@@ -51,9 +52,10 @@ are specific defined depending on the sender and receiver.
     - `instruction`
 - `contents`:
     - If type is `confirmation`, then the then the message contents have
-        - `instructed` 
-        - `contents`
-        - `instruction`
+        - `completed`
+        - `instructed`, which contains the original instruction with in the `contents`:
+            - `instruction`
+            - `instructed_by`
     - If type is `status`, then the then the message contents have
         - `id` of device
         - `status` has a map of `component_id` keys and `status` values

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -178,13 +178,13 @@ func (handler *Handler) onConfirmationMsg(raw Message) error {
 		return fmt.Errorf("received improperly structured confirmation message from device " + raw.DeviceID)
 	}
 	msg := original.(map[string]interface{})
-	innerContents, err := getMapSlice(msg["contents"])
+	instructionContents, err := getMapSlice(msg["contents"])
 	if err != nil {
 		return err
 	}
 
 	var instructionString string
-	for _, instruction := range innerContents {
+	for _, instruction := range instructionContents {
 		instructionString += fmt.Sprintf("%s", instruction["instruction"])
 		// If original message to which device responded with confirmation was sent by front-end,
 		// pass confirmation through

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -178,7 +178,7 @@ func (handler *Handler) onConfirmationMsg(raw Message) error {
 		return fmt.Errorf("received improperly structured confirmation message from device " + raw.DeviceID)
 	}
 	msg := original.(map[string]interface{})
-	innerContents, err := getMapSlice(msg["innerContents"])
+	innerContents, err := getMapSlice(msg["contents"])
 	if err != nil {
 		return err
 	}
@@ -186,6 +186,13 @@ func (handler *Handler) onConfirmationMsg(raw Message) error {
 	var instructionString string
 	for _, instruction := range innerContents {
 		instructionString += fmt.Sprintf("%s", instruction["instruction"])
+		// If original message to which device responded with confirmation was sent by front-end,
+		// pass confirmation through
+		if instruction["instructed_by"] == "front-end" {
+			jsonMessage, _ := json.Marshal(raw)
+			handler.Communicator.Publish("front-end", string(jsonMessage), 3)
+			logrus.Infof("sending confirmation to front-end for instruction %v", instruction["instruction"])
+		}
 	}
 
 	if !value.(bool) {
@@ -195,13 +202,6 @@ func (handler *Handler) onConfirmationMsg(raw Message) error {
 		logrus.Info("device " + raw.DeviceID + " completed instructions: " +
 			instructionString + " at " + raw.TimeSent)
 	}
-	// If original message to which device responded with confirmation was sent by front-end,
-	// pass confirmation through
-	if msg["device_id"] == "front-end" {
-		jsonMessage, _ := json.Marshal(raw)
-		handler.Communicator.Publish("front-end", string(jsonMessage), 3)
-	}
-
 	con := handler.Config.Devices[raw.DeviceID]
 	con.Connection = true
 	handler.Config.Devices[raw.DeviceID] = con
@@ -276,11 +276,11 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 			case "test all":
 				{
 					message := Message{
-						DeviceID: raw.DeviceID,
+						DeviceID: "back-end",
 						TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 						Type:     "instruction",
 						Contents: []map[string]interface{}{
-							{"instruction": "test"},
+							{"instruction": "test", "instructed_by": raw.DeviceID},
 						},
 					}
 					jsonMessage, _ := json.Marshal(&message)
@@ -289,11 +289,11 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 			case "reset all":
 				{
 					message := Message{
-						DeviceID: raw.DeviceID,
+						DeviceID: "back-end",
 						TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 						Type:     "instruction",
 						Contents: []map[string]interface{}{
-							{"instruction": "reset"},
+							{"instruction": "reset", "instructed_by": raw.DeviceID},
 						},
 					}
 					jsonMessage, _ := json.Marshal(&message)
@@ -315,10 +315,14 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 			case "hint":
 				{
 					message := Message{
-						DeviceID: raw.DeviceID,
+						DeviceID: "back-end",
 						TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 						Type:     "instruction",
-						Contents: raw.Contents,
+						Contents: []map[string]interface{}{
+							{"instruction": "hint",
+								"value":         instruction["value"],
+								"instructed_by": raw.DeviceID},
+						},
 					}
 					jsonMessage, _ := json.Marshal(&message)
 					handler.Communicator.Publish("hint", string(jsonMessage), 3)

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -279,8 +279,9 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 						DeviceID: "back-end",
 						TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 						Type:     "instruction",
-						Contents: []map[string]interface{}{
-							{"instruction": "test", "instructed_by": raw.DeviceID},
+						Contents: []map[string]interface{}{{
+							"instruction":   "test",
+							"instructed_by": raw.DeviceID},
 						},
 					}
 					jsonMessage, _ := json.Marshal(&message)
@@ -292,8 +293,9 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 						DeviceID: "back-end",
 						TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 						Type:     "instruction",
-						Contents: []map[string]interface{}{
-							{"instruction": "reset", "instructed_by": raw.DeviceID},
+						Contents: []map[string]interface{}{{
+							"instruction":   "reset",
+							"instructed_by": raw.DeviceID},
 						},
 					}
 					jsonMessage, _ := json.Marshal(&message)
@@ -318,10 +320,10 @@ func (handler *Handler) onInstructionMsg(raw Message) {
 						DeviceID: "back-end",
 						TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 						Type:     "instruction",
-						Contents: []map[string]interface{}{
-							{"instruction": "hint",
-								"value":         instruction["value"],
-								"instructed_by": raw.DeviceID},
+						Contents: []map[string]interface{}{{
+							"instruction":   "hint",
+							"value":         instruction["value"],
+							"instructed_by": raw.DeviceID},
 						},
 					}
 					jsonMessage, _ := json.Marshal(&message)

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -380,8 +380,9 @@ func TestOnConfirmationMsgTrue(t *testing.T) {
 			"instructed": map[string]interface{}{
 				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
-				"contents": []map[string]interface{}{
-					{"instruction": "test", "instructed_by": "front-end"},
+				"contents": []map[string]interface{}{{
+					"instruction":   "test",
+					"instructed_by": "front-end"},
 				},
 				"type": "instruction",
 			},
@@ -404,8 +405,10 @@ func TestOnConfirmationMsgFalse(t *testing.T) {
 			"instructed": map[string]interface{}{
 				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
-				"contents":  []map[string]interface{}{{"instruction": "test", "instructed_by": "front-end"}},
-				"type":      "instruction",
+				"contents": []map[string]interface{}{{
+					"instruction":   "test",
+					"instructed_by": "front-end"}},
+				"type": "instruction",
 			},
 		},
 	}
@@ -423,8 +426,10 @@ func TestOnConfirmationMsgIncorrect1(t *testing.T) {
 			"instructed": map[string]interface{}{
 				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
-				"contents":  []map[string]interface{}{{"instruction": "test", "instructed_by": "front-end"}},
-				"type":      "instruction",
+				"contents": []map[string]interface{}{{
+					"instruction":   "test",
+					"instructed_by": "front-end"}},
+				"type": "instruction",
 			},
 		},
 	}
@@ -442,8 +447,10 @@ func TestOnConfirmationMsgIncorrect2(t *testing.T) {
 			"instructions": map[string]interface{}{
 				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
-				"contents":  map[string]interface{}{"instructions": "test", "instructed_by": "front-end"},
-				"type":      "instructions",
+				"contents": map[string]interface{}{
+					"instructions":  "test",
+					"instructed_by": "front-end"},
+				"type": "instructions",
 			},
 		},
 	}
@@ -461,8 +468,10 @@ func TestOnConfirmationMsgIncorrect3(t *testing.T) {
 			"instructed": map[string]interface{}{
 				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
-				"contents":  []map[string]interface{}{{"instruction": "test", "instructed_by": "front-end"}},
-				"type":      "instruction",
+				"contents": []map[string]interface{}{{
+					"instruction":   "test",
+					"instructed_by": "front-end"}},
+				"type": "instruction",
 			},
 		},
 	}
@@ -480,8 +489,10 @@ func TestMsgMapperConfirmation(t *testing.T) {
 			"instructed": map[string]interface{}{
 				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
-				"contents":  []map[string]interface{}{{"instruction": "test", "instructed_by": "front-end"}},
-				"type":      "instruction",
+				"contents": []map[string]interface{}{{
+					"instruction":   "test",
+					"instructed_by": "front-end"}},
+				"type": "instruction",
 			},
 		},
 	}

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -777,8 +777,9 @@ func TestInstructionResetAll(t *testing.T) {
 		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 		Type:     "instruction",
-		Contents: []map[string]interface{}{
-			{"instruction": "reset", "instructed_by": "front-end"},
+		Contents: []map[string]interface{}{{
+			"instruction":   "reset",
+			"instructed_by": "front-end"},
 		},
 	}
 	statusMsg := Message{

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -378,10 +378,10 @@ func TestOnConfirmationMsgTrue(t *testing.T) {
 		Contents: map[string]interface{}{
 			"completed": true,
 			"instructed": map[string]interface{}{
-				"device_id": "front-end",
+				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
 				"contents": []map[string]interface{}{
-					{"instruction": "test"},
+					{"instruction": "test", "instructed_by": "front-end"},
 				},
 				"type": "instruction",
 			},
@@ -404,7 +404,7 @@ func TestOnConfirmationMsgFalse(t *testing.T) {
 			"instructed": map[string]interface{}{
 				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
-				"contents":  []map[string]interface{}{{"instruction": "test"}},
+				"contents":  []map[string]interface{}{{"instruction": "test", "instructed_by": "front-end"}},
 				"type":      "instruction",
 			},
 		},
@@ -423,7 +423,7 @@ func TestOnConfirmationMsgIncorrect1(t *testing.T) {
 			"instructed": map[string]interface{}{
 				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
-				"contents":  []map[string]interface{}{{"instruction": "test"}},
+				"contents":  []map[string]interface{}{{"instruction": "test", "instructed_by": "front-end"}},
 				"type":      "instruction",
 			},
 		},
@@ -442,7 +442,7 @@ func TestOnConfirmationMsgIncorrect2(t *testing.T) {
 			"instructions": map[string]interface{}{
 				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
-				"contents":  map[string]interface{}{"instructions": "test"},
+				"contents":  map[string]interface{}{"instructions": "test", "instructed_by": "front-end"},
 				"type":      "instructions",
 			},
 		},
@@ -461,7 +461,7 @@ func TestOnConfirmationMsgIncorrect3(t *testing.T) {
 			"instructed": map[string]interface{}{
 				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
-				"contents":  []map[string]interface{}{{"instruction": "test"}},
+				"contents":  []map[string]interface{}{{"instruction": "test", "instructed_by": "front-end"}},
 				"type":      "instruction",
 			},
 		},
@@ -480,7 +480,7 @@ func TestMsgMapperConfirmation(t *testing.T) {
 			"instructed": map[string]interface{}{
 				"device_id": "back-end",
 				"time_sent": "05-12-2019 09:42:10",
-				"contents":  []map[string]interface{}{{"instruction": "test"}},
+				"contents":  []map[string]interface{}{{"instruction": "test", "instructed_by": "front-end"}},
 				"type":      "instruction",
 			},
 		},
@@ -732,11 +732,11 @@ func TestInstructionTestAll(t *testing.T) {
 		},
 	}
 	responseMsg := Message{
-		DeviceID: "front-end",
+		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 		Type:     "instruction",
 		Contents: []map[string]interface{}{
-			{"instruction": "test"},
+			{"instruction": "test", "instructed_by": "front-end"},
 		},
 	}
 	jsonMessage, _ := json.Marshal(&responseMsg)
@@ -763,11 +763,11 @@ func TestInstructionResetAll(t *testing.T) {
 		},
 	}
 	responseMsg := Message{
-		DeviceID: "front-end",
+		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 		Type:     "instruction",
 		Contents: []map[string]interface{}{
-			{"instruction": "reset"},
+			{"instruction": "reset", "instructed_by": "front-end"},
 		},
 	}
 	statusMsg := Message{
@@ -832,7 +832,20 @@ func TestInstructionHint(t *testing.T) {
 			},
 		},
 	}
-	jsonHintMessage, _ := json.Marshal(&instructionMsg)
+	responseMessage := Message{
+		DeviceID: "back-end",
+		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
+		Type:     "instruction",
+		Contents: []map[string]interface{}{
+			{
+				"instruction":   "hint",
+				"value":         "some useful hint",
+				"instructed_by": "front-end",
+			},
+		},
+	}
+
+	jsonHintMessage, _ := json.Marshal(&responseMessage)
 	communicatorMock.On("Publish", "hint", string(jsonHintMessage), 3)
 	handler.msgMapper(instructionMsg)
 	communicatorMock.AssertNumberOfCalls(t, "Publish", 1)
@@ -857,7 +870,19 @@ func TestInstructionNotFromWrongDevice(t *testing.T) {
 			},
 		},
 	}
-	jsonHintMessage, _ := json.Marshal(&instructionMsg)
+	responseMessage := Message{
+		DeviceID: "back-end",
+		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
+		Type:     "instruction",
+		Contents: []map[string]interface{}{
+			{
+				"instruction":   "hint",
+				"value":         "some useful hint",
+				"instructed_by": "front-end",
+			},
+		},
+	}
+	jsonHintMessage, _ := json.Marshal(&responseMessage)
 	communicatorMock.On("Publish", "hint", string(jsonHintMessage), 3)
 	handler.msgMapper(instructionMsg)
 	communicatorMock.AssertNumberOfCalls(t, "Publish", 0)

--- a/back-end/src/sciler/handler/handler_test.go
+++ b/back-end/src/sciler/handler/handler_test.go
@@ -746,8 +746,9 @@ func TestInstructionTestAll(t *testing.T) {
 		DeviceID: "back-end",
 		TimeSent: time.Now().Format("02-01-2006 15:04:05"),
 		Type:     "instruction",
-		Contents: []map[string]interface{}{
-			{"instruction": "test", "instructed_by": "front-end"},
+		Contents: []map[string]interface{}{{
+			"instruction":   "test",
+			"instructed_by": "front-end"},
 		},
 	}
 	jsonMessage, _ := json.Marshal(&responseMsg)


### PR DESCRIPTION
### Issue
Closes GH-80

## Contents
includes `instructed_by` parameter in instruction messages send by back-end, which is used to send confirmations to front-end

This should be used for all instructions to devices, which can be confirmed (so status messages are excluded)