### PR TITLE
created logger for front-end

### DIFF
--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { MatSnackBar, MatSnackBarConfig } from "@angular/material";
 import { Subscription } from "rxjs";
 import { Devices } from "./components/device/devices";
 import { Timers } from "./components/timer/timers";
+import { Logger } from "./logger";
 
 @Component({
   selector: "app-root",
@@ -17,12 +18,14 @@ export class AppComponent implements OnInit, OnDestroy {
   title = "S.C.I.L.E.R";
   nameOfRoom = "Super awesome escape";
   jsonConvert: JsonConvert;
+  logger: Logger;
   subscription: Subscription;
   topics = ["front-end"];
   deviceList: Devices;
   timerList: Timers;
 
   constructor(private mqttService: MqttService, private snackBar: MatSnackBar) {
+    this.logger = new Logger();
     this.jsonConvert = new JsonConvert();
     this.deviceList = new Devices();
     this.timerList = new Timers();
@@ -54,15 +57,15 @@ export class AppComponent implements OnInit, OnDestroy {
     this.subscription = this.mqttService
       .observe(topic)
       .subscribe((message: IMqttMessage) => {
-        console.log(
-          "log: received on topic " +
+        this.logger.log("info",
+          "received on topic " +
             message.topic +
             ", message: " +
             message.payload.toString()
         );
         this.processMessage(message.payload.toString());
       });
-    console.log("log: subscribed to topic: " + topic);
+    this.logger.log("info", "subscribed to topic: " + topic);
   }
 
   /**
@@ -78,8 +81,8 @@ export class AppComponent implements OnInit, OnDestroy {
     );
     const jsonMessage: string = this.jsonConvert.serialize(msg);
     this.mqttService.unsafePublish("back-end", JSON.stringify(jsonMessage));
-    console.log(
-      "log: sent instruction message: " + JSON.stringify(jsonMessage)
+    this.logger.log("info",
+      "sent instruction message: " + JSON.stringify(jsonMessage)
     );
   }
 
@@ -95,7 +98,7 @@ export class AppComponent implements OnInit, OnDestroy {
     });
     const jsonMessage: string = this.jsonConvert.serialize(msg);
     this.mqttService.unsafePublish("back-end", JSON.stringify(jsonMessage));
-    console.log("log: sent status message: " + JSON.stringify(jsonMessage));
+    this.logger.log("info", "sent status message: " + JSON.stringify(jsonMessage));
   }
 
   /**
@@ -108,7 +111,7 @@ export class AppComponent implements OnInit, OnDestroy {
     });
     const jsonMessage: string = this.jsonConvert.serialize(msg);
     this.mqttService.unsafePublish("back-end", JSON.stringify(jsonMessage));
-    console.log("log: sent connection message: " + JSON.stringify(jsonMessage));
+    this.logger.log("info", "sent connection message: " + JSON.stringify(jsonMessage));
   }
 
   /**
@@ -167,7 +170,7 @@ export class AppComponent implements OnInit, OnDestroy {
         break;
       }
       default:
-        console.log("log: received invalid message type " + msg.type);
+        this.logger.log("error", "received invalid message type " + msg.type);
         break;
     }
   }

--- a/front-end/src/app/components/device/device.spec.ts
+++ b/front-end/src/app/components/device/device.spec.ts
@@ -25,7 +25,6 @@ describe("DeviceComponent", () => {
   });
 
   it("should set status", () => {
-    console.log(device);
     expect(device.getValue("door")).toBe(true);
     const jsonData = JSON.parse(`{ "door" : false }`);
     device.updateStatus(jsonData);

--- a/front-end/src/app/logger.ts
+++ b/front-end/src/app/logger.ts
@@ -1,3 +1,4 @@
+import { formatMS } from "./components/timer/timer.component";
 /**
  * This logger will log the messages from the application.
  * It is currently implemented to log to the console, but this can be changed to log to a file on the server-side.
@@ -11,8 +12,8 @@ export class Logger {
    * @param level: info, warning or error
    * @param msg to log
    */
-  log(level: string, msg: string) {
-    console.log ("time=" + new Date()
+  public log(level: string, msg: string) {
+    console.log("time=" + new Date().toLocaleString()
       + ", level=" + level
       + ", msg=" + msg);
   }

--- a/front-end/src/app/logger.ts
+++ b/front-end/src/app/logger.ts
@@ -1,0 +1,19 @@
+/**
+ * This logger will log the messages from the application.
+ * It is currently implemented to log to the console, but this can be changed to log to a file on the server-side.
+ */
+export class Logger {
+
+  constructor() {}
+
+  /**
+   * Log a message with a certain level of severity.
+   * @param level: info, warning or error
+   * @param msg to log
+   */
+  log(level: string, msg: string) {
+    console.log ("time=" + new Date()
+      + ", level=" + level
+      + ", msg=" + msg);
+  }
+}


### PR DESCRIPTION
### Issue 
Closes GH-66

## Content
Creates a logger for the front-end. 
This currently prints to console, but includes level and time. 
This can easily be changed to print to a file on server side if preferable, as you only need to change one place now

## Log format
```
time=9-1-2020 11:05:09, level=info, msg=sent instruction message: {"device_id":"front-end","time_sent":"09-12-2019 11:05:09","type":"instruction","contents":[{"instruction":"send status"}]}
```