### PR TITLE
183 buttons

### DIFF
--- a/back-end/src/sciler/config/workingConfigTypes.go
+++ b/back-end/src/sciler/config/workingConfigTypes.go
@@ -134,7 +134,7 @@ func (t *Timer) Stop() error {
 }
 
 // Done finishes the timer as if it ran out of time
-// can not finish a timer that is already Expired
+// cannot finish a timer that is already Expired
 func (t *Timer) Done(handler InstructionSender) error {
 	if t.State == "stateExpired" {
 		return fmt.Errorf("timer %v is already Expired and can not be finished again", t.ID)

--- a/back-end/src/sciler/handler/handler.go
+++ b/back-end/src/sciler/handler/handler.go
@@ -74,9 +74,14 @@ func (handler *Handler) msgMapper(raw Message) {
 }
 
 // onStatusMsg is the function to process status messages.
+// front-end sends status message with button = true, then immediately button = false,
+// and already updates its own state, faster than the back-end messages are received again,
+// so we don't send again, as otherwise it has already reset to false, then receives messages for true false again.
 func (handler *Handler) onStatusMsg(raw Message) {
 	handler.updateStatus(raw)
-	handler.sendStatus(raw.DeviceID)
+	if raw.DeviceID != "front-end" {
+		handler.sendStatus(raw.DeviceID)
+	}
 	handler.sendFrontEndStatus(raw)
 	handler.HandleEvent(raw.DeviceID)
 	handler.sendEventStatus()

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -469,6 +469,19 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
   }
 
   /**
+   * Only if the game is running can a rule be executed manually.
+   */
+  getGameStateInGame() {
+    const general = this.timerList.getTimer("general");
+    if (general !== null) {
+      if (general.getState() === "stateActive") {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * Stops timers, then create new variables and timers
    */
   public resetConfig() {

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -318,10 +318,10 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
   sendStatusFrontEnd() {
     const device = this.deviceList.getDevice("front-end");
     if (device != null) {
-      const status = device.status;
+      const statusMap = device.status;
       const statusMsg = {};
-      for (const key of status.keys()) {
-        statusMsg[key] = status.get(key);
+      for (const key of statusMap.keys()) {
+        statusMsg[key] = statusMap.get(key).status; // get the status from Comp
       }
       this.sendStatus(statusMsg);
     }

--- a/front-end/src/app/components/device/device.component.css
+++ b/front-end/src/app/components/device/device.component.css
@@ -3,23 +3,18 @@
   padding-right: 5px;
 }
 
-.component-cell {
-  white-space: pre-wrap;
+/*Styling the status expansion panels.*/
+::ng-deep .status-expansion .mat-expansion-panel-body {
+  padding: 0;
 }
+.mat-expansion-panel-header, .mat-expansion-panel {
+  background-color: #EEEEEE;
+}
+
 
 /*Button columns should be button width.*/
 .test-column {
   width: 64px;
-}
-.unfold-cell {
-  width: 75px;
-}
-.collapse-button {
-  background-color: #7280ce;
-  width: 75px;
-}
-.unfold-button {
-  width: 75px;
 }
 
 /*With small screens, do not show test button*/

--- a/front-end/src/app/components/device/device.component.css
+++ b/front-end/src/app/components/device/device.component.css
@@ -1,17 +1,28 @@
-.mat-row:hover {
-  background-color: #DBDBDB;
-}
-
-.component-cell {
-  white-space: pre-line;
-}
+/*Keep space between component and its status*/
 .comp-pad-right {
   padding-right: 5px;
 }
+
+.component-cell {
+  white-space: pre-wrap;
+}
+
+/*Button columns should be button width.*/
 .test-column {
   width: 64px;
 }
+.unfold-cell {
+  width: 75px;
+}
+.collapse-button {
+  background-color: #7280ce;
+  width: 75px;
+}
+.unfold-button {
+  width: 75px;
+}
 
+/*With small screens, do not show test button*/
 @media only screen and (max-width: 470px) {
   .test-column {
     display: none;

--- a/front-end/src/app/components/device/device.component.css
+++ b/front-end/src/app/components/device/device.component.css
@@ -9,7 +9,7 @@
   padding-right: 5px;
 }
 .test-column {
-
+  width: 64px;
 }
 
 @media only screen and (max-width: 470px) {

--- a/front-end/src/app/components/device/device.component.css
+++ b/front-end/src/app/components/device/device.component.css
@@ -4,13 +4,31 @@
 }
 
 /*Styling the status expansion panels.*/
-::ng-deep .status-expansion .mat-expansion-panel-body {
+::ng-deep .status-panel .mat-expansion-panel-body {
   padding: 0;
 }
-.mat-expansion-panel-header, .mat-expansion-panel {
+.mat-expansion-panel {
   background-color: #EEEEEE;
 }
-
+.mat-expansion-panel-header {
+  background-color: #EEEEEE;
+  height: 24px !important;
+}
+.panel-cell {
+  vertical-align: top;
+}
+.component-table .mat-row {
+  height: auto;
+}
+.component-table .mat-cell {
+  padding: 2px 2px 2px 2px;
+}
+.component-cell {
+  text-align: left;
+}
+.status-cell {
+  text-align: right;
+}
 
 /*Button columns should be button width.*/
 .test-column {

--- a/front-end/src/app/components/device/device.component.css
+++ b/front-end/src/app/components/device/device.component.css
@@ -8,6 +8,9 @@
 .comp-pad-right {
   padding-right: 5px;
 }
+.test-column {
+
+}
 
 @media only screen and (max-width: 470px) {
   .test-column {

--- a/front-end/src/app/components/device/device.component.html
+++ b/front-end/src/app/components/device/device.component.html
@@ -15,7 +15,7 @@
         </td>
       </ng-container>
       <ng-container matColumnDef="unfold">
-        <th mat-header-cell *matHeaderCellDef class="custom-md-table-header onderdeel-header">Laat status zien</th>
+        <th mat-header-cell *matHeaderCellDef class="custom-md-table-header">Laat status zien</th>
         <td mat-cell *matCellDef="let element" class="unfold-cell comp-pad-right">
           <ng-container *ngIf="collapsed.get(element.id)">
             <button mat-button class="mat-raised-button unfold-button" color=primary (click)="collapseComponents(element.id)">
@@ -30,16 +30,14 @@
         </td>
       </ng-container>
       <ng-container matColumnDef="component">
-        <th mat-header-cell *matHeaderCellDef class="custom-md-table-header onderdeel-header">Onderdeel</th>
-        <td mat-cell id="{{ element.id }}-component" *matCellDef="let element" class="component-cell comp-pad-right">
-            {{ getComponents(element.status, element.id) }}
-        </td>
+        <th mat-header-cell *matHeaderCellDef class="custom-md-table-header comp-pad-right">Onderdeel</th>
+        <!--Needs to be one line, otherwise spaces are added to text (due to wrap)-->
+        <td mat-cell id="{{ element.id }}-component" *matCellDef="let element" class="component-cell comp-pad-right">{{getComponents(element.status, element.id)}}</td>
       </ng-container>
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef class="custom-md-table-header">Status</th>
-        <td mat-cell id="{{element.id}}-status" *matCellDef="let element" class="component-cell">
-          {{ formatStatus(element.status, element.id) }}
-        </td>
+        <!--Needs to be one line, otherwise spaces are added to text (due to wrap)-->
+        <td mat-cell id="{{element.id}}-status" *matCellDef="let element" class="component-cell status-cell">{{formatStatus(element.status, element.id)}}</td>
       </ng-container>
       <ng-container matColumnDef="test">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="test-column custom-md-table-header">Test</th>

--- a/front-end/src/app/components/device/device.component.html
+++ b/front-end/src/app/components/device/device.component.html
@@ -14,10 +14,25 @@
           <ng-container *ngIf="!element.connection"><span class="cross">&#10006;</span></ng-container>
         </td>
       </ng-container>
+      <ng-container matColumnDef="unfold">
+        <th mat-header-cell *matHeaderCellDef class="custom-md-table-header onderdeel-header">Laat status zien</th>
+        <td mat-cell *matCellDef="let element" class="unfold-cell comp-pad-right">
+          <ng-container *ngIf="collapsed.get(element.id)">
+            <button mat-button class="mat-raised-button unfold-button" color=primary (click)="collapseComponents(element.id)">
+              status
+            </button>
+          </ng-container>
+          <ng-container *ngIf="!collapsed.get(element.id)">
+            <button mat-button class="mat-raised-button collapse-button" color=primary (click)="collapseComponents(element.id)">
+              sluit
+            </button>
+          </ng-container>
+        </td>
+      </ng-container>
       <ng-container matColumnDef="component">
         <th mat-header-cell *matHeaderCellDef class="custom-md-table-header onderdeel-header">Onderdeel</th>
         <td mat-cell id="{{ element.id }}-component" *matCellDef="let element" class="component-cell comp-pad-right">
-          {{ getComponents(element.status, element.id) }}
+            {{ getComponents(element.status, element.id) }}
         </td>
       </ng-container>
       <ng-container matColumnDef="status">
@@ -30,7 +45,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="test-column custom-md-table-header">Test</th>
         <td mat-cell *matCellDef="let element" (click)="$event.stopPropagation()">
           <button mat-button class="mat-raised-button test-column" color=primary
-                  disabled="{{ !app.getGameStateInGame() }}" (click)="testDevice(element.id)">Test</button>
+                  disabled="{{ !app.getGameStateInGame() }}" (click)="testDevice(element.id)">test</button>
         </td>
       </ng-container>
 

--- a/front-end/src/app/components/device/device.component.html
+++ b/front-end/src/app/components/device/device.component.html
@@ -16,17 +16,17 @@
       </ng-container>
       <ng-container matColumnDef="unfold">
         <th mat-header-cell *matHeaderCellDef class="custom-md-table-header">Laat status zien</th>
-        <td mat-cell *matCellDef="let element">
-          <mat-expansion-panel class="status-expansion" [expanded]="false">
-            <mat-expansion-panel-header>
+        <td mat-cell *matCellDef="let element" class="panel-cell">
+          <mat-expansion-panel class="status-panel" [expanded]="false">
+            <mat-expansion-panel-header collapsedHeight="*" expandedHeight="*">
             </mat-expansion-panel-header>
             <table mat-table [dataSource]="getComponentList(element.id)"
-                   class="mat-elevation-z8 custom-md-table">
+                   class="mat-elevation-z8 custom-md-table component-table">
                 <ng-container matColumnDef="component">
-                  <td mat-cell *matCellDef="let comp" class="comp-pad-right">{{ comp.id }}</td>
+                  <td mat-cell *matCellDef="let comp" class="component-cell">{{ comp.id }}</td>
                 </ng-container>
                 <ng-container matColumnDef="status">
-                  <td mat-cell *matCellDef="let comp">{{ comp.status }}</td>
+                  <td mat-cell *matCellDef="let comp" class="status-cell">{{ comp.status }}</td>
                 </ng-container>
               <tr mat-row *matRowDef="let compRow; columns: componentColumns;"></tr>
             </table>

--- a/front-end/src/app/components/device/device.component.html
+++ b/front-end/src/app/components/device/device.component.html
@@ -16,28 +16,22 @@
       </ng-container>
       <ng-container matColumnDef="unfold">
         <th mat-header-cell *matHeaderCellDef class="custom-md-table-header">Laat status zien</th>
-        <td mat-cell *matCellDef="let element" class="unfold-cell comp-pad-right">
-          <ng-container *ngIf="collapsed.get(element.id)">
-            <button mat-button class="mat-raised-button unfold-button" color=primary (click)="collapseComponents(element.id)">
-              status
-            </button>
-          </ng-container>
-          <ng-container *ngIf="!collapsed.get(element.id)">
-            <button mat-button class="mat-raised-button collapse-button" color=primary (click)="collapseComponents(element.id)">
-              sluit
-            </button>
-          </ng-container>
+        <td mat-cell *matCellDef="let element">
+          <mat-expansion-panel class="status-expansion" [expanded]="false">
+            <mat-expansion-panel-header>
+            </mat-expansion-panel-header>
+            <table mat-table [dataSource]="getComponentList(element.id)"
+                   class="mat-elevation-z8 custom-md-table">
+                <ng-container matColumnDef="component">
+                  <td mat-cell *matCellDef="let comp" class="comp-pad-right">{{ comp.id }}</td>
+                </ng-container>
+                <ng-container matColumnDef="status">
+                  <td mat-cell *matCellDef="let comp">{{ comp.status }}</td>
+                </ng-container>
+              <tr mat-row *matRowDef="let compRow; columns: componentColumns;"></tr>
+            </table>
+          </mat-expansion-panel>
         </td>
-      </ng-container>
-      <ng-container matColumnDef="component">
-        <th mat-header-cell *matHeaderCellDef class="custom-md-table-header comp-pad-right">Onderdeel</th>
-        <!--Needs to be one line, otherwise spaces are added to text (due to wrap)-->
-        <td mat-cell id="{{ element.id }}-component" *matCellDef="let element" class="component-cell comp-pad-right">{{getComponents(element.status, element.id)}}</td>
-      </ng-container>
-      <ng-container matColumnDef="status">
-        <th mat-header-cell *matHeaderCellDef class="custom-md-table-header">Status</th>
-        <!--Needs to be one line, otherwise spaces are added to text (due to wrap)-->
-        <td mat-cell id="{{element.id}}-status" *matCellDef="let element" class="component-cell status-cell">{{formatStatus(element.status, element.id)}}</td>
       </ng-container>
       <ng-container matColumnDef="test">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="test-column custom-md-table-header">Test</th>
@@ -48,7 +42,7 @@
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="deviceColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: deviceColumns;" (click)="collapseComponents(row)"></tr>
+      <tr mat-row *matRowDef="let row; columns: deviceColumns;"></tr>
     </table>
   </div>
 </div>

--- a/front-end/src/app/components/device/device.component.html
+++ b/front-end/src/app/components/device/device.component.html
@@ -19,6 +19,7 @@
         <td mat-cell *matCellDef="let element" class="panel-cell">
           <mat-expansion-panel class="status-panel" [expanded]="false">
             <mat-expansion-panel-header collapsedHeight="*" expandedHeight="*">
+              status van onderdelen
             </mat-expansion-panel-header>
             <table mat-table [dataSource]="getComponentList(element.id)"
                    class="mat-elevation-z8 custom-md-table component-table">

--- a/front-end/src/app/components/device/device.component.html
+++ b/front-end/src/app/components/device/device.component.html
@@ -5,7 +5,7 @@
            class="mat-elevation-z8 custom-md-table">
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header">Apparaat</th>
-        <td mat-cell *matCellDef="let element"> {{ element.id }} </td>
+        <td mat-cell *matCellDef="let element"> {{ getName(element.id) }} </td>
       </ng-container>
       <ng-container matColumnDef="connection">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header">Connectie</th>
@@ -16,7 +16,7 @@
       </ng-container>
       <ng-container matColumnDef="component">
         <th mat-header-cell *matHeaderCellDef class="custom-md-table-header onderdeel-header">Onderdeel</th>
-        <td mat-cell id="{{element.id}}-component" *matCellDef="let element" class="component-cell comp-pad-right">
+        <td mat-cell id="{{ element.id }}-component" *matCellDef="let element" class="component-cell comp-pad-right">
           {{ getComponents(element.status, element.id) }}
         </td>
       </ng-container>
@@ -29,7 +29,8 @@
       <ng-container matColumnDef="test">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="test-column custom-md-table-header">Test</th>
         <td mat-cell *matCellDef="let element" (click)="$event.stopPropagation()">
-          <button mat-button class="mat-raised-button test-column" color=primary (click)="testDevice(element.id)">Test</button>
+          <button mat-button class="mat-raised-button test-column" color=primary
+                  disabled="{{ !app.getGameStateInGame() }}" (click)="testDevice(element.id)">Test</button>
         </td>
       </ng-container>
 

--- a/front-end/src/app/components/device/device.component.spec.ts
+++ b/front-end/src/app/components/device/device.component.spec.ts
@@ -11,11 +11,10 @@ import {
   MatInputModule,
   MatPaginatorModule,
   MatSortModule,
-  MatTableDataSource,
+  MatExpansionModule,
   MatTableModule
 } from "@angular/material";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { Device } from "./device";
 
 describe("DeviceComponent", () => {
   let component: DeviceComponent;
@@ -31,6 +30,7 @@ describe("DeviceComponent", () => {
         MatPaginatorModule,
         MatFormFieldModule,
         MatInputModule,
+        MatExpansionModule,
         MatSnackBarModule,
         BrowserAnimationsModule
       ],
@@ -59,8 +59,7 @@ describe("DeviceComponent", () => {
     const tableHeaders = compiled.querySelectorAll("th");
     expect(tableHeaders.item(0).textContent).toContain("Apparaat");
     expect(tableHeaders.item(1).textContent).toContain("Connectie");
-    expect(tableHeaders.item(2).textContent).toContain("Onderdeel");
-    expect(tableHeaders.item(3).textContent).toContain("Status");
-    expect(tableHeaders.item(4).textContent).toContain("Test");
+    expect(tableHeaders.item(2).textContent).toContain("Laat status zien");
+    expect(tableHeaders.item(3).textContent).toContain("Test");
   });
 });

--- a/front-end/src/app/components/device/device.component.ts
+++ b/front-end/src/app/components/device/device.component.ts
@@ -15,7 +15,7 @@ export class DeviceComponent implements OnInit {
   /**
    * The keys used by the table to retrieve data from the DataSource
    */
-  deviceColumns: string[] = ["id", "connection", "component", "status", "test"];
+  deviceColumns: string[] = ["id", "connection", "unfold", "component", "status", "test"];
 
   /**
    * Map keeping track of which rows are collapsed.
@@ -42,7 +42,7 @@ export class DeviceComponent implements OnInit {
     for (const device of this.app.deviceList.all.values()) {
       devices.push(device);
       if (!this.collapsed.has(device.id)) {
-        this.collapsed.set(device.id, false);
+        this.collapsed.set(device.id, true);
       }
     }
     devices.sort((a: Device, b: Device) => a.id.localeCompare(b.id));
@@ -53,7 +53,7 @@ export class DeviceComponent implements OnInit {
   }
 
   /**
-   * In the table, show the front-end as device with name "operator scherm.
+   * In the table, show the front-end as device with name "operator scherm".
    */
   getName(deviceId: string): string {
     if (deviceId === "front-end") {
@@ -70,10 +70,8 @@ export class DeviceComponent implements OnInit {
    * For the front-end, only show gameState.
    */
   getComponents(status: Map<string, any>, deviceId: string): any {
-    if (!this.collapsed.get(deviceId)) {
-      return "open onderdelen en status";
-    } else if (status.size === 0) {
-      return "geen status";
+    if (this.collapsed.get(deviceId)) {
+      return "";
     } else if (deviceId === "front-end") {
       return "gameState";
     } else {
@@ -95,7 +93,7 @@ export class DeviceComponent implements OnInit {
    * For the front-end only show gameState status.
    */
   formatStatus(status: Map<string, any>, deviceId: string): string {
-    if (!this.collapsed.get(deviceId)) {
+    if (this.collapsed.get(deviceId)) {
       return "";
     } else if (deviceId === "front-end") {
       return status.get("gameState");
@@ -134,12 +132,12 @@ export class DeviceComponent implements OnInit {
   }
 
   /**
-   * Clicking a row should unfold the components and their statuses.
-   * Clicking again should collapse.
-   * @param row the row to collapse with full device data
+   * Clicking the 'status' button should show the components and their statuses.
+   * Clicking the 'sluit' button should hide the components and their statuses.
+   * @param deviceID the status of this device should be shown/hidden
    */
-  collapseComponents(row) {
-    const oldValue = this.collapsed.get(row.id);
-    this.collapsed.set(row.id, !oldValue);
+  collapseComponents(deviceID: string) {
+    const oldValue = this.collapsed.get(deviceID);
+    this.collapsed.set(deviceID, !oldValue);
   }
 }

--- a/front-end/src/app/components/device/device.component.ts
+++ b/front-end/src/app/components/device/device.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
-import {Comp, Device} from "./device";
+import { Comp, Device } from "./device";
 import { AppComponent } from "../../app.component";
 import { MatSort, MatTableDataSource } from "@angular/material";
 

--- a/front-end/src/app/components/device/device.component.ts
+++ b/front-end/src/app/components/device/device.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
-import { Device } from "./device";
+import {Comp, Device} from "./device";
 import { AppComponent } from "../../app.component";
 import { MatSort, MatTableDataSource } from "@angular/material";
 
@@ -13,23 +13,20 @@ import { MatSort, MatTableDataSource } from "@angular/material";
 })
 export class DeviceComponent implements OnInit {
   /**
-   * The keys used by the table to retrieve data from the DataSource
+   * The keys used by the device table to retrieve data from the DataSource.
    */
-  deviceColumns: string[] = ["id", "connection", "unfold", "component", "status", "test"];
-
+  deviceColumns: string[] = ["id", "connection", "unfold", "test"];
   /**
-   * Map keeping track of which rows are collapsed.
+   * The keys used by the component table to retrieve data from the component list.
    */
-  collapsed: Map<string, boolean>;
+  componentColumns: string[] = ["component", "status"];
 
   /**
    * Control the sorting of the table.
    */
   @ViewChild("DeviceTableSort", { static: true }) sort: MatSort;
 
-  constructor(private app: AppComponent) {
-    this.collapsed = new Map<string, boolean>();
-  }
+  constructor(private app: AppComponent) {}
 
   ngOnInit() {}
 
@@ -41,15 +38,30 @@ export class DeviceComponent implements OnInit {
     const devices: Device[] = [];
     for (const device of this.app.deviceList.all.values()) {
       devices.push(device);
-      if (!this.collapsed.has(device.id)) {
-        this.collapsed.set(device.id, true);
-      }
     }
     devices.sort((a: Device, b: Device) => a.id.localeCompare(b.id));
 
     const dataSource = new MatTableDataSource<Device>(devices);
     dataSource.sort = this.sort;
     return dataSource;
+  }
+
+  /**
+   * Returns list of Comp objects with their current status.
+   * For the front-end, only return the game state not the button pressed statuses.
+   */
+  public getComponentList(deviceId: string): Comp[] {
+    const status = this.app.deviceList.getDevice(deviceId).status;
+    if (deviceId === "front-end") {
+      return [status.get("gameState")];
+    }
+    const ret = [];
+    const keys = Array.from(status.keys());
+    keys.sort();
+    keys.forEach((key: string) => {
+      ret.push(status.get(key));
+    });
+    return ret;
   }
 
   /**
@@ -64,64 +76,6 @@ export class DeviceComponent implements OnInit {
   }
 
   /**
-   * Creates list of components (keys of status maps), in alphabetical order.
-   * Returns string with each component on new line.
-   * If components are collapsed, return default.
-   * For the front-end, only show gameState.
-   */
-  getComponents(status: Map<string, any>, deviceId: string): any {
-    if (this.collapsed.get(deviceId)) {
-      return "";
-    } else if (deviceId === "front-end") {
-      return "gameState";
-    } else {
-      const keys = Array.from(status.keys());
-
-      keys.sort();
-      let result = "";
-      keys.forEach((key: string) => {
-        result += key + "\n";
-      });
-      return result;
-    }
-  }
-
-  /**
-   * Creates list of components (keys of status maps), in alphabetical order.
-   * Returns string with each component's value on new line.
-   * If components are collapse, return nothing.
-   * For the front-end only show gameState status.
-   */
-  formatStatus(status: Map<string, any>, deviceId: string): string {
-    if (this.collapsed.get(deviceId)) {
-      return "";
-    } else if (deviceId === "front-end") {
-      return status.get("gameState");
-    } else {
-      const keys = Array.from(status.keys());
-      keys.sort();
-
-      let result = "";
-      keys.forEach((key: string) => {
-        const value = status.get(key);
-        if (Array.isArray(value)) {
-          result += "[";
-          for (let i = 0; i < value.length; i++) {
-            result += value[i];
-            if (i < value.length - 1) {
-              result += ",";
-            }
-          }
-          result += "]\n";
-        } else {
-          result += value + "\n";
-        }
-      });
-      return result;
-    }
-  }
-
-  /**
    * When button is pressed, test a single device.
    * The test button can not be clicked when game is in play (timer is running).
    */
@@ -129,15 +83,5 @@ export class DeviceComponent implements OnInit {
     this.app.sendInstruction([
       { instruction: "test device", device: deviceId }
     ]);
-  }
-
-  /**
-   * Clicking the 'status' button should show the components and their statuses.
-   * Clicking the 'sluit' button should hide the components and their statuses.
-   * @param deviceID the status of this device should be shown/hidden
-   */
-  collapseComponents(deviceID: string) {
-    const oldValue = this.collapsed.get(deviceID);
-    this.collapsed.set(deviceID, !oldValue);
   }
 }

--- a/front-end/src/app/components/device/device.component.ts
+++ b/front-end/src/app/components/device/device.component.ts
@@ -53,15 +53,29 @@ export class DeviceComponent implements OnInit {
   }
 
   /**
+   * In the table, show the front-end as device with name "operator scherm.
+   */
+  getName(deviceId: string): string {
+    if (deviceId === "front-end") {
+      return "operator scherm";
+    } else {
+      return deviceId;
+    }
+  }
+
+  /**
    * Creates list of components (keys of status maps), in alphabetical order.
    * Returns string with each component on new line.
    * If components are collapsed, return default.
+   * For the front-end, only show gameState.
    */
   getComponents(status: Map<string, any>, deviceId: string): any {
     if (!this.collapsed.get(deviceId)) {
       return "open onderdelen en status";
     } else if (status.size === 0) {
       return "geen status";
+    } else if (deviceId === "front-end") {
+      return "gameState";
     } else {
       const keys = Array.from(status.keys());
 
@@ -78,10 +92,13 @@ export class DeviceComponent implements OnInit {
    * Creates list of components (keys of status maps), in alphabetical order.
    * Returns string with each component's value on new line.
    * If components are collapse, return nothing.
+   * For the front-end only show gameState status.
    */
   formatStatus(status: Map<string, any>, deviceId: string): string {
     if (!this.collapsed.get(deviceId)) {
       return "";
+    } else if (deviceId === "front-end") {
+      return status.get("gameState");
     } else {
       const keys = Array.from(status.keys());
       keys.sort();
@@ -108,6 +125,7 @@ export class DeviceComponent implements OnInit {
 
   /**
    * When button is pressed, test a single device.
+   * The test button can not be clicked when game is in play (timer is running).
    */
   testDevice(deviceId: string) {
     this.app.sendInstruction([

--- a/front-end/src/app/components/device/device.spec.ts
+++ b/front-end/src/app/components/device/device.spec.ts
@@ -25,9 +25,9 @@ describe("DeviceComponent", () => {
   });
 
   it("should set status", () => {
-    expect(device.getValue("door")).toBe(true);
+    expect(device.getValue("door").status).toBe(true);
     const jsonData = JSON.parse(`{ "door" : false }`);
     device.updateStatus(jsonData);
-    expect(device.connection).toBe(false);
+    expect(device.getValue("door").status).toBe(false);
   });
 });

--- a/front-end/src/app/components/device/device.ts
+++ b/front-end/src/app/components/device/device.ts
@@ -3,13 +3,13 @@
  */
 export class Device {
   id: string;
-  status: Map<string, any>;
+  status: Map<string, Comp>;
   connection: boolean;
 
   constructor(jsonData) {
     this.id = jsonData.id;
     this.updateConnection(jsonData.connection);
-    this.status = new Map<string, any>();
+    this.status = new Map<string, Comp>();
     this.updateStatus(jsonData.status);
   }
 
@@ -29,10 +29,9 @@ export class Device {
     const keys = Object.keys(jsonStatus);
     for (const key of keys) {
       if (this.status.has(key)) {
-        this.status.delete(key);
-        this.status.set(key, jsonStatus[key]);
+        this.status.get(key).status = jsonStatus[key];
       } else {
-        this.status.set(key, jsonStatus[key]);
+        this.status.set(key, new Comp(key, jsonStatus[key]));
       }
     }
   }
@@ -43,5 +42,18 @@ export class Device {
    */
   getValue(comp) {
     return this.status.get(comp);
+  }
+}
+
+/**
+ * Comp class contains information about a component: its id and status.
+ */
+export class Comp {
+  id: string;
+  status: any;
+
+  constructor(id, status) {
+    this.id = id;
+    this.status = status;
   }
 }

--- a/front-end/src/app/components/device/devices.spec.ts
+++ b/front-end/src/app/components/device/devices.spec.ts
@@ -32,7 +32,7 @@ describe("DeviceComponent", () => {
         }
     `);
     devices.setDevice(jsonData);
-    expect(devices.getDevice("Door").getValue("door")).toBe(true);
+    expect(devices.getDevice("Door").getValue("door").status).toBe(true);
     const jsonData2 = JSON.parse(`{
           "id": "Door",
           "status": {"door": false},
@@ -40,6 +40,6 @@ describe("DeviceComponent", () => {
         }
     `);
     devices.setDevice(jsonData2);
-    expect(devices.getDevice("Door").getValue("door")).toBe(false);
+    expect(devices.getDevice("Door").getValue("door").status).toBe(false);
   });
 });

--- a/front-end/src/app/components/manage/manage.component.css
+++ b/front-end/src/app/components/manage/manage.component.css
@@ -1,4 +1,4 @@
 .generated-button[disabled] {
-  background-color: #7280ce;
-  color: #EEEEEE;
+  /*background-color: #7280ce;*/
+  color: #383838;
 }

--- a/front-end/src/app/components/manage/manage.component.spec.ts
+++ b/front-end/src/app/components/manage/manage.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ManageComponent } from "./manage.component";
 import { MqttModule, MqttService } from "ngx-mqtt";
-import { AppModule, MQTT_SERVICE_OPTIONS } from "../../app.module";
+import { MQTT_SERVICE_OPTIONS } from "../../app.module";
 import { AppComponent } from "../../app.component";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { Overlay } from "@angular/cdk/overlay";

--- a/front-end/src/app/components/manage/manage.component.ts
+++ b/front-end/src/app/components/manage/manage.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from "@angular/core";
 import { AppComponent } from "../../app.component";
-import { Device } from "../device/device";
 import { Button } from "./button";
 
 /**

--- a/front-end/src/app/components/puzzle/puzzle.component.css
+++ b/front-end/src/app/components/puzzle/puzzle.component.css
@@ -3,7 +3,7 @@
   min-width: 20%;
 }
 .rule-status {
-  width: 70px;
+  width: 50px;
 }
 
 @media only screen and (max-width: 470px) {

--- a/front-end/src/app/components/puzzle/puzzle.component.html
+++ b/front-end/src/app/components/puzzle/puzzle.component.html
@@ -21,7 +21,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header">Handmatig afmaken</th>
         <td mat-cell *matCellDef="let element">
           <button mat-button class="mat-raised-button mat-primary" (click)="finishRule(element.id)"
-                  disabled="{{ app.getGameStateInGame() }}">Puzzel eindigen</button>
+                  disabled="{{ app.getGameStateInGame() }}">Wel gedaan</button>
         </td>
       </ng-container>
 

--- a/front-end/src/app/components/puzzle/puzzle.component.html
+++ b/front-end/src/app/components/puzzle/puzzle.component.html
@@ -21,7 +21,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header">Handmatig afmaken</th>
         <td mat-cell *matCellDef="let element">
           <button mat-button class="mat-raised-button mat-primary" (click)="finishRule(element.id)"
-                  disabled="{{ app.getGameStateInGame() }}">Wel gedaan</button>
+                  disabled="{{ app.getGameStateInGame() }}">wel gedaan</button>
         </td>
       </ng-container>
 

--- a/front-end/src/app/components/puzzle/puzzle.component.html
+++ b/front-end/src/app/components/puzzle/puzzle.component.html
@@ -21,7 +21,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="custom-md-table-header">Handmatig afmaken</th>
         <td mat-cell *matCellDef="let element">
           <button mat-button class="mat-raised-button mat-primary" (click)="finishRule(element.id)"
-                  disabled="{{ getGameStateInGame() }}">Puzzel eindigen</button>
+                  disabled="{{ app.getGameStateInGame() }}">Puzzel eindigen</button>
         </td>
       </ng-container>
 

--- a/front-end/src/app/components/puzzle/puzzle.component.ts
+++ b/front-end/src/app/components/puzzle/puzzle.component.ts
@@ -44,21 +44,9 @@ export class PuzzleComponent implements OnInit {
 
   /**
    * When button in the table is pressed, manually override the finished status of rule in back-end.
+   * The finish rule button can only be clicked when game is in play (timer is running).
    */
   finishRule(ruleId: string) {
     this.app.sendInstruction([{ instruction: "finish rule", rule: ruleId }]);
-  }
-
-  /**
-   * Only if the game is running can a rule be executed manually.
-   */
-  getGameStateInGame() {
-    const general = this.app.timerList.getTimer("general");
-    if (general !== null) {
-      if (general.getState() === "stateActive") {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/front-end/src/app/config/config.component.ts
+++ b/front-end/src/app/config/config.component.ts
@@ -43,7 +43,9 @@ export class ConfigComponent implements OnInit {
     });
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.app.uploadedConfig = "";
+  }
 
   /**
    * When clicking the upload button, first reset the file, so the same one can be entered again for re-checking.

--- a/front-end/src/app/config/config.component.ts
+++ b/front-end/src/app/config/config.component.ts
@@ -81,10 +81,10 @@ export class ConfigComponent implements OnInit {
    * Parses JSON and catches error when JSON is invalid.
    */
   getJSONConfig() {
-    try{
-      return JSON.parse(this.data)
+    try {
+      return JSON.parse(this.data);
     } catch (e) {
-      this.errors.push("level I - JSON error: "+ e);
+      this.errors.push("level I - JSON error: " + e);
       this.app.logger.log("error", "error while reading file");
       this.app.uploadedConfig = "Error tijdens uploaden: " + e;
     }

--- a/front-end/src/app/home/home.component.html
+++ b/front-end/src/app/home/home.component.html
@@ -2,10 +2,10 @@
   <div class="left">
     <app-timer></app-timer>
     <app-manage></app-manage>
-    <app-hint></app-hint>
+    <app-device></app-device>
   </div>
   <div class="right">
-    <app-device></app-device>
+    <app-hint></app-hint>
     <app-puzzle></app-puzzle>
   </div>
 </div>

--- a/front-end/src/assets/css/main.css
+++ b/front-end/src/assets/css/main.css
@@ -88,7 +88,7 @@ body { /*body of the index.html*/
 
 
 /*Small screens should have little 'white space'*/
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 1100px) {
   @media only screen and (min-width: 650px) {
     .left {
       margin: 0 5px 0 0;
@@ -115,6 +115,6 @@ body { /*body of the index.html*/
 
   .home-content {
     display: grid;
-    grid-template-columns: 40% 60%;
+    grid-template-columns: 50% 50%;
   }
 }

--- a/front-end/src/assets/css/main.css
+++ b/front-end/src/assets/css/main.css
@@ -54,6 +54,12 @@ body { /*body of the index.html*/
   font-size: 16px;
   border-radius: 4px;
 }
+.check-mark {
+  color: green !important;
+}
+.cross {
+  color: red !important;
+}
 
 
 


### PR DESCRIPTION
closes #183, closes #162

- front-end is shown as 'operator scherm' with only `gameState` as status
- front-end button's pressed status is not resend from back-end (causing flickering)
- adds button for showing statuses of components
- improves button stylings in tables and disables when necessary
- hopefully fixed colors of checkmarks on all devices -> cannot test yet
- [x]  fixes placing of components/statuses with long statuses
- [x] reorganize home


home:
![afbeelding](https://user-images.githubusercontent.com/23522361/73274210-7e452b80-41e5-11ea-8021-8c65a2efabe0.png)
