### PR TITLE
Added support for using SCILER app in an application that uses asyncio

### DIFF
--- a/cc_library/py_scc/sciler/app.py
+++ b/cc_library/py_scc/sciler/app.py
@@ -72,15 +72,18 @@ class Sciler:
         """
         logging.log(level=level, msg=msg)
 
-    def start(self, loop=None, stop=None):
+    def start(self, loop=None, stop=None, blocking=True):
         """
         Starting method to call from the starting script.
         :param loop: possible event loop
         :param stop: possible end function
+        :param blocking: when True, block until keyboard interrupt
         """
         self.__connect()
         try:
-            if loop:
+            if not blocking:
+                self.client.loop_start()
+            elif loop:
                 self.client.loop_start()
                 loop()
             else:
@@ -92,7 +95,19 @@ class Sciler:
                 stop()
             if loop:
                 self.client.loop_stop()
-            self.__stop()
+            if blocking:
+                self.__stop()
+            else:
+                # Callee must call `stop()` method themselves.
+                pass
+        
+    def stop(self):
+        """
+        Stop method for use when the client has been started in non-blocking mode.
+        """
+        logging.info("stop method called, stopping client loop")
+        self.client.loop_stop()
+        self.__stop()
 
     def __stop(self):
         """

--- a/cc_library/py_scc/sciler/device.py
+++ b/cc_library/py_scc/sciler/device.py
@@ -54,13 +54,20 @@ class Device(ABC):
         """
         self.scclib.status_changed()
 
-    def start(self, loop=None, stop=None):
+    def start(self, loop=None, stop=None, blocking=True):
         """
         Passes the request to start the message sender
         :param loop: possible event loop
         :param stop: possible end function
+        :param blocking: set to False to not block when the client thread has started; need to call `stop` manually.
         """
-        self.scclib.start(loop, stop)
+        self.scclib.start(loop=loop, stop=stop, blocking=blocking)
+
+    def stop(self):
+        """
+        Stops the client thread that was started with `start` in non-blocking mode.
+        """
+        self.scclib.stop()
 
     def log(self, msg, level=logging.INFO):
         """


### PR DESCRIPTION
In order to run a SCILER device as a task inside an asyncio application and to have proper response to signals (also for other tasks), it is necessary that the `start` function returns. Then the SCILER device can be run as:

    async def main():
        scilerdevice.start(blocking=False)
        tasks = [asyncio.create_task(....), ...]
        await asyncio.gather(*tasks)
    try:
        asyncio.run(main())
    except KeyboardInterrupt:
        pass
    finally:
        scilerdevice.stop()