### PR TITLE
only check type of value not on contains

### DIFF
--- a/back-end/src/sciler/config/checkConfig.go
+++ b/back-end/src/sciler/config/checkConfig.go
@@ -463,7 +463,7 @@ func checkConstraintsDeviceNumericType(errorParameters []string, constraint Cons
 func checkConstraintsDeviceArrayType(errorParameters []string, constraint Constraint) []string {
 	valueType := reflect.TypeOf(constraint.Value).Kind()
 	comparison := constraint.Comparison
-	if valueType != reflect.Slice {
+	if valueType != reflect.Slice && comparison != "contains" {
 		return []string{fmt.Sprintf("level III - implementation error: on rule %s, constraint on device with id %s: type array/slice expected but %s found as type of the value: %v",
 			errorParameters[0], errorParameters[1], valueType.String(), constraint.Value)}
 	}


### PR DESCRIPTION
constraints on a component with type array would only allow arrays as values, 
compare on a comparison contains would only allow single elements as value to compare,
because of this inconsistency, contains does not work in an end2end process.

The simplest fix is to allow constraints on a component with type array to have any type of value.

A harder fix is to implement contains such that it checks if a array is a subset of an other array, which will need to be done in :
```// contains is a function that checks if a slice contains an element
func contains(list interface{}, element interface{}) bool {
	slice := reflect.ValueOf(list)
	for i := 0; i < slice.Len(); i++ {
		if element == slice.Index(i).Interface() {
			return true
		}
	}
	return false
}
```
for now, the first fix is implemented, an issue has been created for the second fix