### PR TITLE
added notify host instruction for front-end

### DIFF
--- a/back-end/resources/manuals/message_manual.md
+++ b/back-end/resources/manuals/message_manual.md
@@ -102,7 +102,7 @@ are specifically defined depending on the sender and receiver.
             - `instruction`
             - `instructed_by`
     - If type is `instruction`, then the then the message contents have
-             - `instruction` with value `reset` or `status update` or `test` or `setState`
+             - `instruction` with value `reset` or `status update` or `test` or `set state` or `notify host`
     - If type is `status`, then the message contents has
         - `id` of device
         - `status` has a map of `component_id` keys and `status` values

--- a/back-end/src/sciler/config/configHandler.go
+++ b/back-end/src/sciler/config/configHandler.go
@@ -133,6 +133,12 @@ func generateFrontendDevice(config *WorkingConfig) *Device {
 					"set state": "string",
 				},
 			},
+			"notification": {
+				Type: "string",
+				Instructions: map[string]string{
+					"notify host": "string",
+				},
+			},
 		},
 		Status:     status,
 		Connection: false,

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -236,7 +236,7 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
       }
       // when a config has be checked and put to use (only possible on no errors), notify the user
       case "new config": {
-        this.openSnackbar("using new config: " + msg.contents.name, "");
+        this.openSnackbar("using new config: " + msg.contents.name, 3000,"");
         break;
       }
       default:
@@ -256,7 +256,7 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
         jsonData.deviceId +
         " for instruction: " +
         instruction.instruction;
-      this.openSnackbar(display, "");
+      this.openSnackbar(display, 3000, "");
     }
   }
 
@@ -265,7 +265,8 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
    * reset - reset the front-end's device status
    * status update - send front-end's connection status to back-end
    * test - perform a test on the front-end
-   * setState - update the gameState of the front-end and inform the back-end
+   * set state - update the gameState of the front-end and inform the back-end
+   * notify host - notify the host of a message
    */
   private processInstruction(jsonData) {
     for (const action of jsonData) {
@@ -279,12 +280,16 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
           break;
         }
         case "test": {
-          this.openSnackbar("performing instruction test", "");
+          this.openSnackbar("performing instruction test", 5000,"OK");
           break;
         }
         case "set state": {
           this.deviceList.updateDevice(action.component_id, action.value);
           this.sendStatusFrontEnd();
+          break;
+        }
+        case "notify host": {
+          this.openSnackbar(action.value, 8000, "OK");
           break;
         }
         default: {
@@ -460,12 +465,13 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
 
   /**
    * Opens snackbar with duration of 3 seconds.
-   * @param message displays this message
+   * @param message: displays this message
+   * @param duration: duration of message
    * @param action: button to display - optional use
    */
-  public openSnackbar(message: string, action: string) {
+  public openSnackbar(message: string, duration: number, action: string) {
     const snackbar = new MatSnackBarConfig();
-    snackbar.duration = 3000;
+    snackbar.duration = duration;
     snackbar.panelClass = ["custom-snack-bar"];
     this.snackBar.open(message, action, snackbar);
   }

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -236,7 +236,7 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
       }
       // when a config has be checked and put to use (only possible on no errors), notify the user
       case "new config": {
-        this.openSnackbar("using new config: " + msg.contents.name, 3000,"");
+        this.openSnackbar("using new config: " + msg.contents.name, 3000, "");
         break;
       }
       default:
@@ -280,7 +280,7 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
           break;
         }
         case "test": {
-          this.openSnackbar("performing instruction test", 5000,"OK");
+          this.openSnackbar("performing instruction test", 5000, "OK");
           break;
         }
         case "set state": {


### PR DESCRIPTION
can now instruct front end to notify host in config

voorbeeld action:
```
{
"type": "device"
"type_id": "front-end"
"message": [{
  "component_id": "notification",
  "instruction": "notify host",
  "value": "<insert value>"
]}
```