### PR TITLE
double timer tick bug

### DIFF
--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -109,6 +109,7 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
     const generalTimer = { id: "general", duration: 0, state: "stateIdle" };
     this.timerList.setTimer(generalTimer);
     this.resetFrontEndStatus();
+    this.logger.log("debug","RESET RESET RESET \n RESET RESET RESET \n RESET RESET RESET")
   }
 
   /**
@@ -540,9 +541,6 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
    * Stops timers, then create new variables and timers
    */
   public resetConfig() {
-    this.stopTimers();
-    this.initializeVariables();
-    this.initializeTimers();
     this.resetFrontEndStatus();
   }
 }

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -109,7 +109,6 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
     const generalTimer = { id: "general", duration: 0, state: "stateIdle" };
     this.timerList.setTimer(generalTimer);
     this.resetFrontEndStatus();
-    this.logger.log("debug","RESET RESET RESET \n RESET RESET RESET \n RESET RESET RESET")
   }
 
   /**

--- a/front-end/src/app/app.component.ts
+++ b/front-end/src/app/app.component.ts
@@ -63,6 +63,7 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
     this.logger = new Logger();
     this.jsonConvert = new JsonConvert();
     this.initializeVariables();
+    this.initializeTimers();
 
     const topics = ["front-end"];
     for (const topic of topics) {
@@ -73,7 +74,6 @@ export class AppComponent extends FullScreen implements OnInit, OnDestroy {
       this.logger.log("info", "connected to broker on " + config.host);
       this.sendInstruction([{ instruction: "send setup" }]);
       this.sendConnection(true);
-      this.initializeTimers();
     });
 
     this.mqttService.onOffline.subscribe(() => {

--- a/front-end/src/app/components/timer/timer.ts
+++ b/front-end/src/app/components/timer/timer.ts
@@ -24,7 +24,7 @@ export class Timer {
    * A tick subtracts 1 second (1000 ms) from its duration.
    */
   tick() {
-    this.duration = this.duration - 1000;
+    this.duration = Math.max(this.duration - 1000, 0);
   }
 
   update(dur, sta) {
@@ -37,6 +37,7 @@ export class Timer {
  * Format the time in milliseconds to a string in the format hh:mm:ss.
  */
 export function formatMS(timeInMS) {
+  const milseconds = parseInt(((timeInMS ) ).toString(), 10);
   const seconds = parseInt(((timeInMS / 1000) % 60).toString(), 10);
   const minutes = parseInt(((timeInMS / (1000 * 60)) % 60).toString(), 10);
   const hours = parseInt(((timeInMS / (1000 * 60 * 60)) % 24).toString(), 10);
@@ -44,7 +45,7 @@ export function formatMS(timeInMS) {
   const m = minutes < 10 ? "0" + minutes : minutes;
   const s = seconds < 10 ? "0" + seconds : seconds;
 
-  return h + ":" + m + ":" + s;
+  return h + ":" + m + ":" + s +":"+milseconds;
 }
 
 /**

--- a/front-end/src/app/components/timer/timer.ts
+++ b/front-end/src/app/components/timer/timer.ts
@@ -37,7 +37,6 @@ export class Timer {
  * Format the time in milliseconds to a string in the format hh:mm:ss.
  */
 export function formatMS(timeInMS) {
-  const milseconds = parseInt(((timeInMS ) ).toString(), 10);
   const seconds = parseInt(((timeInMS / 1000) % 60).toString(), 10);
   const minutes = parseInt(((timeInMS / (1000 * 60)) % 60).toString(), 10);
   const hours = parseInt(((timeInMS / (1000 * 60 * 60)) % 24).toString(), 10);
@@ -45,7 +44,7 @@ export function formatMS(timeInMS) {
   const m = minutes < 10 ? "0" + minutes : minutes;
   const s = seconds < 10 ? "0" + seconds : seconds;
 
-  return h + ":" + m + ":" + s +":"+milseconds;
+  return h + ":" + m + ":" + s;
 }
 
 /**


### PR DESCRIPTION
The timer would add ticks every second in the front-end every time the broker dis and reconnected, so I moved the timer init out of the onConnect method

durations of front-end timers are now at least 0

removed useless resetters in the front-end since every action in there was also already preformed on setup.