### PR TITLE
Python sciler lib no network autoconnect

### DIFF
--- a/cc_library/py_scc/sciler/app.py
+++ b/cc_library/py_scc/sciler/app.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from datetime import datetime
 
 import paho.mqtt.client as mqtt
@@ -129,10 +130,19 @@ class Sciler:
         try:
             self.client.connect(self.host, self.port, keepalive=10)
             logging.info("connected to broker")
+            return
         except ConnectionRefusedError:
             logging.error("connection was refused")
         except TimeoutError:
             logging.error("connecting failed, socket timed out")
+        except OSError:
+            logging.error("connecting failed, OSError, probably not (yet) connected to the router")
+        except BaseException as error:
+            print("Unexpected error: {}".format(error))
+
+        time.sleep(1)
+        logging.warning("trying to reconnect")
+        self.__connect()
 
     def __on_connect(self, client, userdata, flags, rc):
         """

--- a/cc_library/py_scc/setup.py
+++ b/cc_library/py_scc/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sciler",
-    version="0.2.2",
+    version="0.2.3",
     author="Raccoon Serious Games",
     author_email="BEP@raccoon.games",
     description="Client library for S.C.I.L.E.R.",


### PR DESCRIPTION
Fixed bug where if the initial connection in the library fails, the library crashes.
Now OSErrors are handled specifically and all other errors are handled generically.
When an error is thrown this is caught, logged and then reconnect is tried automatically until it connects (or is stopped).

Pypi is updated to 0.2.3

This PR fixed the issue that = a client computer crashes when it boots faster than the router or broker when power is turned on simultaneously